### PR TITLE
feat: frontmatter parsing and sub-resource operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,20 +78,80 @@ Notes:
 
 > ⚠️ **Warning**: This API does not provide HTTPS natively. To secure your deployment and prevent credentials and sensitive data from being transmitted in plaintext over the internet, you must place it behind a secure reverse proxy (e.g., NGINX, Traefik, or Cloudflare Tunnel) that handles HTTPS.
 
-## API Endpoints
+## API
 
 ### Files
-- `GET /files` - List all markdown files
-- `GET /files/{path}` - Read the contents of a specific file
-- `POST /files/{path}` - Create a new file
-- `PATCH /files/{path}` - Move/Rename a file
-- `PUT /files{path}` - Update the contents of an existing file
+
+#### Primary Routes
+- `GET /files` - List all markdown files in your vault with their metadata, including path, size, and modification dates
+- `GET /files/{path}` - Get the complete file representation including metadata, YAML frontmatter, and markdown body content
+- `POST /files/{path}` - Create a new markdown file at the specified path using a JSON object with 'frontmatter' (YAML object) and 'body' (markdown string) fields
+- `PUT /files/{path}` - Replace the entire raw content of the file. The content should include YAML frontmatter (between --- markers) followed by markdown body content
+- `PATCH /files/{path}` - Merge new metadata with existing file metadata, including moving/renaming the file to a new path within the vault
+
+#### Sub-Resource Routes
+
+##### Raw File
+
+- `GET /files/{path}/raw` - Get the raw contents of the markdown file at the specified path, including frontmatter and body content exactly as stored
+- `POST /files/{path}/raw` - Create a new markdown file at the specified path with raw text content. The content should include YAML frontmatter (between --- markers) followed by markdown body content
+- `PUT /files/{path}/raw` - Replace the entire raw content of the file. The content should include YAML frontmatter (between --- markers) followed by markdown body content
+
+##### File Metadata
+
+- `GET /files/{path}/metadata` - Get the file's metadata including name, path, size, creation date, and last modification date
+- `PATCH /files/{path}/metadata` - Merge new metadata with existing file metadata, including moving/renaming the file to a new path within the vault
+##### Markdown Frontmatter
+
+- `GET /files/{path}/frontmatter` - Get the YAML frontmatter of the file as a JSON object
+- `PUT /files/{path}/frontmatter` - Replace the entire YAML frontmatter of the file with a new JSON object containing frontmatter data
+- `PATCH /files/{path}/frontmatter` - Merge a new JSON object containing frontmatter data with the existing YAML frontmatter
+##### Markdown Body
+
+- `GET /files/{path}/body` - Get the markdown body content of the file, excluding the frontmatter section
+- `PUT /files/{path}/body` - Replace the entire markdown body content of the file, preserving the frontmatter
+
+#### Response Schema
+```json
+{
+  "metadata": {
+    "name": "string",
+    "path": "string",
+    "type": "file",
+    "size": 0,
+    "created": "datetime",
+    "modified": "datetime"
+  },
+  "content": {
+    "frontmatter": {
+      "key": "value"
+    },
+    "body": "string"
+  }
+}
+```
 
 ### Folders
-- `GET /folders` - List all folders
-- `GET /folders/{path}` - List files in a specific folder
-- `POST /folders/{path}` - Create a new folder
-- `PATCH /folders/{path}` - Move/Rename a folder
+
+#### Primary Routes
+
+- `GET /folders` - List all folders in your vault
+- `GET /folders/{path}` - Get the folder's metadata including name, path, size, creation date, and last modification date
+- `POST /folders/{path}` - Create a new folder at the specified path
+- `PATCH /folders/{path}` - Move/rename the folder to a new path within the vault
+
+#### Response Schema
+```json
+{
+  "metadata": {
+    "name": "string",
+    "path": "string",
+    "type": "folder",
+    "created": "datetime",
+    "modified": "datetime"
+  }
+}
+```
 
 For detailed API documentation, including request/response schemas and examples, visit the Swagger UI at `http://localhost:8000/docs`.
 
@@ -113,7 +173,9 @@ I've enjoyed using the [Cursor](https://www.cursor.com/)-like [Obsidian Copilot]
 - [x] Create a base local API for file and folders.
 - [x] Make deployable in a local Docker services.
 - [x] Provide an authentication mechanism.
-- [ ] Implement a MCP server for the API.
-- [ ] Add additional endpoints like DELETE and perhaps MERGE. But I'd want configuration or authorization to be in plact to control access.
-- [ ] Provide file/folder metadata. Perhaps integrating file frontmatter into metadata.
+- [x] File and folder metadata/stats.
+- [x] Frontmatter parsing.
+- [ ] MCP server wrapper around API.
+- [ ] Sync / embedding management for vector store.
+- [ ] DELETE methods.
 

--- a/app/file_routes.py
+++ b/app/file_routes.py
@@ -1,14 +1,34 @@
 import os
-from fastapi import APIRouter, Depends, HTTPException, status
-from typing import Annotated, List
+from fastapi import APIRouter, Depends, Response
+from typing import Annotated
 from app.authentication import ObsidianHTTPBearer
 from app.path_validation import (
     validate_existing_markdown_file,
     validate_new_markdown_file,
     validate_destination_path
 )
-from app.utils import walk_files, read_file_to_response
-from app.models import FileCreateRequest, FilePutRequest, FilePatchRequest, FileResponse
+from app.utils import (
+    walk_files, 
+    get_file_response,
+    get_file_metadata_response,
+    get_file_frontmatter_response,
+    get_file_body_response,
+    get_raw_response
+)
+from app.models import (
+    FileCreateRequest, 
+    FilePutRequest, 
+    FilePatchRequest,
+    MetadataPatchRequest,
+    FrontmatterPutRequest,
+    FrontmatterPatchRequest,
+    BodyPutRequest,
+    RawPutRequest,
+    ParsedFileResponse,
+    BaseFileResponse,
+    FrontmatterResponse,
+    BodyResponse
+)
 
 obsidian_security = ObsidianHTTPBearer()
 file_router = APIRouter(
@@ -19,86 +39,203 @@ file_router = APIRouter(
 
 @file_router.get(
     "/", 
-    summary="List files", 
+    summary="List Files", 
     description="List all markdown files in your vault.",
-    response_model=list[FileResponse]
+    response_model=list[ParsedFileResponse]
 )
 def list_files():
     return walk_files()
 
 @file_router.get(
+    "/{vault_file_path:path}/raw", 
+    summary="Get Raw File",
+    response_description='Get the raw contents of the markdown file at the specified path, including frontmatter.',
+    response_class=Response
+)
+async def read_raw_file(
+    vault_file_path: str,
+    full_file_path: Annotated[str, Depends(validate_existing_markdown_file)]
+) -> Response:
+    return get_raw_response(full_file_path)
+
+@file_router.get(
+    "/{vault_file_path:path}/metadata", 
+    summary="Get File Metadata",
+    response_description='Get just the metadata of the file (name, path, size, dates).',
+    response_model=BaseFileResponse
+)
+async def read_file_metadata(
+    vault_file_path: str,
+    full_file_path: Annotated[str, Depends(validate_existing_markdown_file)]
+) -> BaseFileResponse:
+    return get_file_metadata_response(full_file_path)
+
+@file_router.get(
+    "/{vault_file_path:path}/frontmatter", 
+    summary="Get File Frontmatter",
+    response_description='Get just the frontmatter of the file.',
+    response_model=FrontmatterResponse
+)
+async def read_file_frontmatter(
+    vault_file_path: str,
+    full_file_path: Annotated[str, Depends(validate_existing_markdown_file)]
+) -> FrontmatterResponse:
+    return get_file_frontmatter_response(full_file_path)
+
+@file_router.get(
+    "/{vault_file_path:path}/body", 
+    summary="Get File Body",
+    response_description='Get just the body content of the file without frontmatter.',
+    response_model=BodyResponse
+)
+async def read_file_body(
+    vault_file_path: str,
+    full_file_path: Annotated[str, Depends(validate_existing_markdown_file)]
+) -> BodyResponse:
+    return get_file_body_response(full_file_path)
+
+@file_router.get(
     "/{vault_file_path:path}", 
-    summary="Read a file",
-    response_description='Get the contents of the markdown file at the specified path.',
-    response_model=FileResponse
+    summary="Get File",
+    response_description='Get the complete file including metadata, frontmatter, and body.',
+    response_model=ParsedFileResponse
 )
 async def read_file(
     vault_file_path: str,
     full_file_path: Annotated[str, Depends(validate_existing_markdown_file)]
-) -> FileResponse:
-    return read_file_to_response(full_file_path)
+) -> ParsedFileResponse:
+    return get_file_response(full_file_path)
 
 @file_router.post(
     "/{vault_file_path:path}", 
-    summary="Create a new file",
+    summary="Create File",
     response_description='Create a new markdown file at the specified path with the specified content.',
-    response_model=FileResponse
+    response_model=ParsedFileResponse
 )
 async def create_file(
     vault_file_path: str,
     request_model: FileCreateRequest,
     full_file_path: Annotated[str, Depends(validate_new_markdown_file)]
-) -> FileResponse:
+) -> ParsedFileResponse:
     os.makedirs(os.path.dirname(full_file_path), exist_ok=True)
     with open(full_file_path, 'w', encoding='utf-8') as f:
         f.write(request_model.content)
-    return read_file_to_response(full_file_path)
+    return get_file_response(full_file_path)
 
 @file_router.patch(
     "/{vault_file_path:path}",
-    summary="Update file content and/or path",
+    summary="Update File (Merge)",
     response_description='Update the file content and/or move/rename the file to a new path.',
-    response_model=FileResponse
+    response_model=ParsedFileResponse
 )
 async def patch_file(
     vault_file_path: str,
     full_file_path: Annotated[str, Depends(validate_existing_markdown_file)],
     request_model: FilePatchRequest = None
-) -> FileResponse:
-    # If no request model or no fields are provided, return current state
+) -> ParsedFileResponse:
     if not request_model or not request_model.model_dump(exclude_unset=True):
-        return read_file_to_response(full_file_path)
+        return get_file_response(full_file_path)
         
-    # Handle path update if provided
     if request_model.path is not None:
         full_destination_path = validate_destination_path(request_model.path, vault_file_path)
-        if os.path.exists(full_destination_path):
-            raise HTTPException(status_code=400, detail="Destination file already exists")
         os.makedirs(os.path.dirname(full_destination_path), exist_ok=True)
         os.rename(full_file_path, full_destination_path)
         full_file_path = full_destination_path
         vault_file_path = request_model.path
 
-    # Handle content update if provided
     if request_model.content is not None:
         with open(full_file_path, 'w', encoding='utf-8') as f:
             f.write(request_model.content)
     
-    # Return the updated file info
-    return read_file_to_response(full_file_path)
+    return get_file_response(full_file_path)
 
 @file_router.put(
     "/{vault_file_path:path}", 
-    summary="Update an existing file",
+    summary="Update File (Replace)",
     response_description='Update the contents of the specified markdown file with the new specified content.',
-    response_model=FileResponse
+    response_model=ParsedFileResponse
 )
 async def put_file(
     vault_file_path: str,
     request_model: FilePutRequest,
     full_file_path: Annotated[str, Depends(validate_existing_markdown_file)]
-) -> FileResponse:
+) -> ParsedFileResponse:
     with open(full_file_path, 'w', encoding='utf-8') as f:
         f.write(request_model.content)
         
-    return read_file_to_response(full_file_path)
+    return get_file_response(full_file_path)
+
+@file_router.patch(
+    "/{vault_file_path:path}/metadata",
+    summary="Update File Metadata",
+    response_description='Update the file metadata (move/rename).',
+    response_model=BaseFileResponse
+)
+async def patch_file_metadata(
+    vault_file_path: str,
+    full_file_path: Annotated[str, Depends(validate_existing_markdown_file)],
+    request_model: MetadataPatchRequest
+) -> BaseFileResponse:
+    if request_model.path is not None:
+        full_destination_path = validate_destination_path(request_model.path, vault_file_path)
+        os.makedirs(os.path.dirname(full_destination_path), exist_ok=True)
+        os.rename(full_file_path, full_destination_path)
+        full_file_path = full_destination_path
+    
+    return get_file_metadata_response(full_file_path)
+
+@file_router.put(
+    "/{vault_file_path:path}/frontmatter",
+    summary="Replace Frontmatter",
+    response_description='Replace the entire frontmatter of the file.',
+    response_model=FrontmatterResponse
+)
+async def put_file_frontmatter(
+    vault_file_path: str,
+    full_file_path: Annotated[str, Depends(validate_existing_markdown_file)],
+    request_model: FrontmatterPutRequest
+) -> FrontmatterResponse:
+    update_frontmatter(full_file_path, request_model.frontmatter)
+    return get_file_frontmatter_response(full_file_path)
+
+@file_router.patch(
+    "/{vault_file_path:path}/frontmatter",
+    summary="Update Frontmatter",
+    response_description='Update the frontmatter of the file by merging with existing frontmatter.',
+    response_model=FrontmatterResponse
+)
+async def patch_file_frontmatter(
+    vault_file_path: str,
+    full_file_path: Annotated[str, Depends(validate_existing_markdown_file)],
+    request_model: FrontmatterPatchRequest
+) -> FrontmatterResponse:
+    merge_frontmatter(full_file_path, request_model.frontmatter)
+    return get_file_frontmatter_response(full_file_path)
+
+@file_router.put(
+    "/{vault_file_path:path}/body",
+    summary="Replace Body",
+    response_description='Replace the entire body content of the file.',
+    response_model=BodyResponse
+)
+async def put_file_body(
+    vault_file_path: str,
+    full_file_path: Annotated[str, Depends(validate_existing_markdown_file)],
+    request_model: BodyPutRequest
+) -> BodyResponse:
+    update_body(full_file_path, request_model.body)
+    return get_file_body_response(full_file_path)
+
+@file_router.put(
+    "/{vault_file_path:path}/raw",
+    summary="Replace Raw Content",
+    response_description='Replace the entire raw content of the file.',
+    response_class=Response
+)
+async def put_raw_file(
+    vault_file_path: str,
+    full_file_path: Annotated[str, Depends(validate_existing_markdown_file)],
+    request_model: RawPutRequest
+) -> Response:
+    update_file_content(full_file_path, request_model.content)
+    return get_raw_response(full_file_path)

--- a/app/file_routes.py
+++ b/app/file_routes.py
@@ -29,7 +29,7 @@ from app.utils import (
 from app.models import (
     MarkdownFile,
     FileMetadata,
-    MetadataPatchRequest,
+    Path,
     MarkdownContent
 )
 
@@ -190,7 +190,7 @@ async def put_file_body(
 async def patch_file_metadata(
     vault_file_path: str,
     full_file_path: Annotated[str, Depends(validate_existing_markdown_file)],
-    request_model: MetadataPatchRequest
+    request_model: Path
 ) -> MarkdownFile:
     if request_model.path is not None:
         full_destination_path = validate_destination_path(request_model.path, vault_file_path)

--- a/app/file_routes.py
+++ b/app/file_routes.py
@@ -1,33 +1,39 @@
+# Standard library imports
 import os
-from fastapi import APIRouter, Depends, Response
+# Third-party imports
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import PlainTextResponse
 from typing import Annotated
+# Local application imports
 from app.authentication import ObsidianHTTPBearer
 from app.path_validation import (
     validate_existing_markdown_file,
     validate_new_markdown_file,
-    validate_destination_path
+    validate_destination_path,
+    validate_markdown_content
 )
 from app.utils import (
-    walk_files, 
-    get_file_response,
-    get_file_metadata_response,
-    get_file_frontmatter_response,
-    get_file_body_response,
-    get_raw_response
+    # Read operations
+    read_file,
+    read_markdown_file,
+    read_stats,
+    walk_files,
+    get_markdown_file_model,
+    # Write operations
+    write_content,
+    write_body,
+    write_frontmatter,
+    merge_frontmatter,
+    write_markdown_file,
 )
 from app.models import (
-    FileCreateRequest, 
-    ParsedFileResponse,
-    BaseFileResponse,
-    FrontmatterResponse,
-    BodyResponse,
+    MarkdownFile,
+    FileMetadata,
     MetadataPatchRequest,
-    FrontmatterPutRequest,
-    FrontmatterPatchRequest,
-    BodyPutRequest,
-    RawPutRequest
+    MarkdownContent
 )
 
+# Router setup
 obsidian_security = ObsidianHTTPBearer()
 file_router = APIRouter(
     prefix="/files",
@@ -35,162 +41,172 @@ file_router = APIRouter(
     dependencies=[Depends(obsidian_security)]
 )
 
+# List operations
 @file_router.get(
     "/", 
     summary="List Files", 
-    description="List all markdown files in your vault.",
-    response_model=list[ParsedFileResponse]
+    description="List all markdown files in your vault with their metadata, including path, size, and modification dates."
 )
-def list_files():
-    return walk_files()
+async def list_files() -> list[MarkdownFile]:
+    return await walk_files()
 
-@file_router.get(
-    "/{vault_file_path:path}/raw", 
-    summary="Get Raw File",
-    response_description='Get the raw contents of the markdown file at the specified path, including frontmatter.',
-    response_class=Response
-)
-async def read_raw_file(
-    vault_file_path: str,
-    full_file_path: Annotated[str, Depends(validate_existing_markdown_file)]
-) -> Response:
-    return get_raw_response(full_file_path)
-
-@file_router.get(
-    "/{vault_file_path:path}/metadata", 
-    summary="Get File Metadata",
-    response_description='Get just the metadata of the file (name, path, size, dates).',
-    response_model=BaseFileResponse
-)
-async def read_file_metadata(
-    vault_file_path: str,
-    full_file_path: Annotated[str, Depends(validate_existing_markdown_file)]
-) -> BaseFileResponse:
-    return get_file_metadata_response(full_file_path)
-
-@file_router.get(
-    "/{vault_file_path:path}/frontmatter", 
-    summary="Get File Frontmatter",
-    response_description='Get just the frontmatter of the file.',
-    response_model=FrontmatterResponse
-)
-async def read_file_frontmatter(
-    vault_file_path: str,
-    full_file_path: Annotated[str, Depends(validate_existing_markdown_file)]
-) -> FrontmatterResponse:
-    return get_file_frontmatter_response(full_file_path)
-
-@file_router.get(
-    "/{vault_file_path:path}/body", 
-    summary="Get File Body",
-    response_description='Get just the body content of the file without frontmatter.',
-    response_model=BodyResponse
-)
-async def read_file_body(
-    vault_file_path: str,
-    full_file_path: Annotated[str, Depends(validate_existing_markdown_file)]
-) -> BodyResponse:
-    return get_file_body_response(full_file_path)
-
+# Read operations
 @file_router.get(
     "/{vault_file_path:path}", 
     summary="Get File",
-    response_description='Get the complete file including metadata, frontmatter, and body.',
-    response_model=ParsedFileResponse
+    response_description='Get the complete file representation including metadata, YAML frontmatter, and markdown body content.'
 )
 async def read_file(
     vault_file_path: str,
     full_file_path: Annotated[str, Depends(validate_existing_markdown_file)]
-) -> ParsedFileResponse:
-    return get_file_response(full_file_path)
+) -> MarkdownFile:
+    return await get_markdown_file_model(full_file_path)
+
+@file_router.get(
+    "/{vault_file_path:path}/raw", 
+    summary="Get Raw File",
+    response_description='Get the raw contents of the markdown file at the specified path, including frontmatter and body content exactly as stored.',
+    response_class=PlainTextResponse
+)
+async def read_raw_file(
+    vault_file_path: str,
+    full_file_path: Annotated[str, Depends(validate_existing_markdown_file)]
+) -> str:
+    return await read_file(full_file_path)
+
+@file_router.get(
+    "/{vault_file_path:path}/metadata", 
+    summary="Get File Metadata",
+    response_description='Get the file\'s metadata including name, path, size, creation date, and last modification date.'
+)
+async def read_file_metadata(
+    vault_file_path: str,
+    full_file_path: Annotated[str, Depends(validate_existing_markdown_file)]
+) -> FileMetadata:
+    return await read_stats(full_file_path)
+
+@file_router.get(
+    "/{vault_file_path:path}/frontmatter", 
+    summary="Get File Frontmatter",
+    response_description='Get the YAML frontmatter of the file as a JSON object.'
+)
+async def read_file_frontmatter(
+    vault_file_path: str,
+    full_file_path: Annotated[str, Depends(validate_existing_markdown_file)]
+) -> dict:
+    _, frontmatter = await read_markdown_file(full_file_path)
+    return frontmatter or {}
+
+@file_router.get(
+    "/{vault_file_path:path}/body", 
+    summary="Get File Body",
+    response_description='Get the markdown body content of the file, excluding the frontmatter section.',
+    response_class=PlainTextResponse
+)
+async def read_file_body(
+    vault_file_path: str,
+    full_file_path: Annotated[str, Depends(validate_existing_markdown_file)]
+) -> str:
+    body, _ = await read_markdown_file(full_file_path)
+    return body
+
+# Create operations
+
+@file_router.post(
+    "/{vault_file_path:path}/raw", 
+    summary="Create File (Raw)",
+    response_description='Create a new markdown file at the specified path with raw text content. The content should include YAML frontmatter (between --- markers) followed by markdown body content.'
+)
+async def create_file_raw(
+    request: Request,
+    vault_file_path: str,
+    full_file_path: Annotated[str, Depends(validate_new_markdown_file)],
+    content: Annotated[str, Depends(validate_markdown_content)]
+) -> MarkdownFile:
+    await write_content(full_file_path, content)
+    return await get_markdown_file_model(full_file_path)
 
 @file_router.post(
     "/{vault_file_path:path}", 
-    summary="Create File",
-    response_description='Create a new markdown file at the specified path with the specified content.',
-    response_model=ParsedFileResponse
+    summary="Create File (Structured)",
+    response_description='Create a new markdown file at the specified path using a JSON object with \'frontmatter\' (YAML object) and \'body\' (markdown string) fields.'
 )
-async def create_file(
+async def create_file_structured(
     vault_file_path: str,
-    request_model: FileCreateRequest,
-    full_file_path: Annotated[str, Depends(validate_new_markdown_file)]
-) -> ParsedFileResponse:
-    os.makedirs(os.path.dirname(full_file_path), exist_ok=True)
-    with open(full_file_path, 'w', encoding='utf-8') as f:
-        f.write(request_model.content)
-    return get_file_response(full_file_path)
+    full_file_path: Annotated[str, Depends(validate_new_markdown_file)],
+    request_model: MarkdownContent
+) -> MarkdownFile:
+    await write_markdown_file(full_file_path, request_model.frontmatter, request_model.body)
+    return await get_markdown_file_model(full_file_path)
+
+
+# Update operations
+@file_router.put(
+    "/{vault_file_path:path}/raw",
+    summary="Replace Raw Content",
+    response_description='Replace the entire raw content of the file. The content should include YAML frontmatter (between --- markers) followed by markdown body content.'
+)
+async def put_raw_file(
+    vault_file_path: str,
+    full_file_path: Annotated[str, Depends(validate_existing_markdown_file)],
+    request: Request,
+    content: Annotated[str, Depends(validate_markdown_content)]
+) -> MarkdownFile:
+    await write_content(full_file_path, content)
+    return await get_markdown_file_model(full_file_path)
+
+@file_router.put(
+    "/{vault_file_path:path}/frontmatter",
+    summary="Replace Frontmatter",
+    response_description='Replace the entire YAML frontmatter of the file with a new JSON object containing frontmatter data.'
+)
+async def put_file_frontmatter(
+    vault_file_path: str,
+    full_file_path: Annotated[str, Depends(validate_existing_markdown_file)],
+    json_body: dict
+) -> MarkdownFile:
+    await write_frontmatter(full_file_path, json_body)
+    return await get_markdown_file_model(full_file_path)
+
+@file_router.put(
+    "/{vault_file_path:path}/body",
+    summary="Replace Body",
+    response_description='Replace the entire markdown body content of the file, preserving the frontmatter.'
+)
+async def put_file_body(
+    vault_file_path: str,
+    full_file_path: Annotated[str, Depends(validate_existing_markdown_file)],
+    str_body: str
+) -> MarkdownFile:
+    await write_body(full_file_path, str_body)
+    return await get_markdown_file_model(full_file_path)
 
 @file_router.patch(
     "/{vault_file_path:path}/metadata",
-    summary="Update File Metadata",
-    response_description='Update the file metadata (move/rename).',
-    response_model=BaseFileResponse
+    summary="Merge File Metadata",
+    response_description='Merge new metadata with existing file metadata, including moving/renaming the file to a new path within the vault.'
 )
 async def patch_file_metadata(
     vault_file_path: str,
     full_file_path: Annotated[str, Depends(validate_existing_markdown_file)],
     request_model: MetadataPatchRequest
-) -> BaseFileResponse:
+) -> MarkdownFile:
     if request_model.path is not None:
         full_destination_path = validate_destination_path(request_model.path, vault_file_path)
         os.makedirs(os.path.dirname(full_destination_path), exist_ok=True)
         os.rename(full_file_path, full_destination_path)
-        full_file_path = full_destination_path
     
-    return get_file_metadata_response(full_file_path)
-
-@file_router.put(
-    "/{vault_file_path:path}/frontmatter",
-    summary="Replace Frontmatter",
-    response_description='Replace the entire frontmatter of the file.',
-    response_model=FrontmatterResponse
-)
-async def put_file_frontmatter(
-    vault_file_path: str,
-    full_file_path: Annotated[str, Depends(validate_existing_markdown_file)],
-    request_model: FrontmatterPutRequest
-) -> FrontmatterResponse:
-    update_frontmatter(full_file_path, request_model.frontmatter)
-    return get_file_frontmatter_response(full_file_path)
+    return await get_markdown_file_model(full_destination_path)
 
 @file_router.patch(
     "/{vault_file_path:path}/frontmatter",
-    summary="Update Frontmatter",
-    response_description='Update the frontmatter of the file by merging with existing frontmatter.',
-    response_model=FrontmatterResponse
+    summary="Merge Frontmatter",
+    response_description='Merge a new JSON object containing frontmatter data with the existing YAML frontmatter.'
 )
 async def patch_file_frontmatter(
     vault_file_path: str,
     full_file_path: Annotated[str, Depends(validate_existing_markdown_file)],
-    request_model: FrontmatterPatchRequest
-) -> FrontmatterResponse:
-    merge_frontmatter(full_file_path, request_model.frontmatter)
-    return get_file_frontmatter_response(full_file_path)
-
-@file_router.put(
-    "/{vault_file_path:path}/body",
-    summary="Replace Body",
-    response_description='Replace the entire body content of the file.',
-    response_model=BodyResponse
-)
-async def put_file_body(
-    vault_file_path: str,
-    full_file_path: Annotated[str, Depends(validate_existing_markdown_file)],
-    request_model: BodyPutRequest
-) -> BodyResponse:
-    update_body(full_file_path, request_model.body)
-    return get_file_body_response(full_file_path)
-
-@file_router.put(
-    "/{vault_file_path:path}/raw",
-    summary="Replace Raw Content",
-    response_description='Replace the entire raw content of the file.',
-    response_class=Response
-)
-async def put_raw_file(
-    vault_file_path: str,
-    full_file_path: Annotated[str, Depends(validate_existing_markdown_file)],
-    request_model: RawPutRequest
-) -> Response:
-    update_file_content(full_file_path, request_model.content)
-    return get_raw_response(full_file_path)
+    json_body: dict
+) -> MarkdownFile:
+    await merge_frontmatter(full_file_path, json_body)
+    return await get_markdown_file_model(full_file_path)

--- a/app/folder_routes.py
+++ b/app/folder_routes.py
@@ -19,7 +19,7 @@ from app.utils import (
 )
 from app.models import (
     Folder,
-    MetadataPatchRequest
+    Path
 )
 
 # Router setup
@@ -73,7 +73,7 @@ async def create_folder(
 async def move_folder(
     vault_folder_path: str,
     full_folder_path: Annotated[str, Depends(validate_existing_folder)],
-    request_model: MetadataPatchRequest
+    request_model: Path
 ) -> Folder:
     full_destination_path = validate_destination_path(request_model.path, vault_folder_path)
     os.makedirs(os.path.dirname(full_destination_path), exist_ok=True)

--- a/app/folder_routes.py
+++ b/app/folder_routes.py
@@ -1,15 +1,28 @@
+# Standard library imports
 import os
+
+# Third-party imports
 from fastapi import APIRouter, Depends
 from typing import Annotated
+
+# Local application imports
 from app.authentication import ObsidianHTTPBearer
 from app.path_validation import (
     validate_existing_folder,
     validate_new_folder,
     validate_destination_path
 )
-from app.utils import walk_folders, get_folder_response
-from app.models import FolderResponse, FolderPatchRequest
+from app.utils import (
+    # Read operations
+    walk_folders,
+    get_folder_model,
+)
+from app.models import (
+    Folder,
+    MetadataPatchRequest
+)
 
+# Router setup
 obsidian_security = ObsidianHTTPBearer()
 folder_router = APIRouter(
     prefix="/folders",
@@ -17,58 +30,52 @@ folder_router = APIRouter(
     dependencies=[Depends(obsidian_security)]
 )
 
+# List operations
 @folder_router.get(
     "/", 
     summary="List Folders",
-    description="List all folders in your vault.",
-    response_model=list[FolderResponse]
+    description="List all folders in your vault."
 )
-async def list_folders() -> list[FolderResponse]:
-    return walk_folders()
+async def list_folders() -> list[Folder]:
+    return await walk_folders()
 
+# Read operations
 @folder_router.get(
     "/{vault_folder_path:path}", 
     summary="Get Folder",
-    response_description='Get the folder at the specified path.',
-    response_model=FolderResponse
+    response_description='Get the folder\'s metadata including name, path, size, creation date, and last modification date.'
 )
-async def list_folder_files(
+async def read_folder(
     vault_folder_path: str,
     full_folder_path: Annotated[str, Depends(validate_existing_folder)]
-) -> FolderResponse:
-    return get_folder_response(full_folder_path)
+) -> Folder:
+    return await get_folder_model(full_folder_path)
 
+# Create operations
 @folder_router.post(
     "/{vault_folder_path:path}", 
     summary="Create Folder",
-    response_description='Create a new folder at the specified path.',
-    response_model=FolderResponse
+    response_description='Create a new folder at the specified path.'
 )
 async def create_folder(
     vault_folder_path: str,
     full_folder_path: Annotated[str, Depends(validate_new_folder)]
-) -> FolderResponse:
+) -> Folder:
     os.makedirs(full_folder_path, exist_ok=True)
-    return get_folder_response(full_folder_path)
+    return await get_folder_model(full_folder_path)
 
+# Update operations
 @folder_router.patch(
     "/{vault_folder_path:path}",
-    summary="Update Folder",
-    response_description='Move or rename the specified folder to the new specified path.',
-    response_model=FolderResponse
+    summary="Move Folder",
+    response_description='Move/rename the folder to a new path within the vault.'
 )
-async def patch_folder(
+async def move_folder(
     vault_folder_path: str,
     full_folder_path: Annotated[str, Depends(validate_existing_folder)],
-    request_model: FolderPatchRequest = None
-) -> FolderResponse:
-    # If no request model or no fields are provided, return current state
-    if not request_model or not request_model.model_dump(exclude_unset=True):
-        return get_folder_response(full_folder_path)
-        
-    # Handle path update if provided
-    if request_model.path is not None:
-        full_destination_path = validate_destination_path(request_model.path, vault_folder_path)
-        os.makedirs(os.path.dirname(full_destination_path), exist_ok=True)
-        os.rename(full_folder_path, full_destination_path)
-    return get_folder_response(full_destination_path)
+    request_model: MetadataPatchRequest
+) -> Folder:
+    full_destination_path = validate_destination_path(request_model.path, vault_folder_path)
+    os.makedirs(os.path.dirname(full_destination_path), exist_ok=True)
+    os.rename(full_folder_path, full_destination_path)
+    return await get_folder_model(full_destination_path)

--- a/app/folder_routes.py
+++ b/app/folder_routes.py
@@ -1,13 +1,13 @@
 import os
-from fastapi import APIRouter, Depends, HTTPException, status
-from typing import Annotated, List
+from fastapi import APIRouter, Depends
+from typing import Annotated
 from app.authentication import ObsidianHTTPBearer
 from app.path_validation import (
     validate_existing_folder,
     validate_new_folder,
     validate_destination_path
 )
-from app.utils import walk_folders, read_folder_to_response
+from app.utils import walk_folders, get_folder_response
 from app.models import FolderResponse, FolderPatchRequest
 
 obsidian_security = ObsidianHTTPBearer()
@@ -19,28 +19,28 @@ folder_router = APIRouter(
 
 @folder_router.get(
     "/", 
-    summary="List all folders",
-    response_description='List all of the folders in your vault.',
+    summary="List Folders",
+    description="List all folders in your vault.",
     response_model=list[FolderResponse]
 )
-async def list_folders() -> List[FolderResponse]:
+async def list_folders() -> list[FolderResponse]:
     return walk_folders()
 
 @folder_router.get(
     "/{vault_folder_path:path}", 
-    summary="List files in a folder",
-    response_description='List all of the markdown files in the specified folder.',
+    summary="Get Folder",
+    response_description='Get the folder at the specified path.',
     response_model=FolderResponse
 )
 async def list_folder_files(
     vault_folder_path: str,
     full_folder_path: Annotated[str, Depends(validate_existing_folder)]
 ) -> FolderResponse:
-    return read_folder_to_response(full_folder_path)
+    return get_folder_response(full_folder_path)
 
 @folder_router.post(
     "/{vault_folder_path:path}", 
-    summary="Create a new folder",
+    summary="Create Folder",
     response_description='Create a new folder at the specified path.',
     response_model=FolderResponse
 )
@@ -49,11 +49,11 @@ async def create_folder(
     full_folder_path: Annotated[str, Depends(validate_new_folder)]
 ) -> FolderResponse:
     os.makedirs(full_folder_path, exist_ok=True)
-    return read_folder_to_response(full_folder_path)
+    return get_folder_response(full_folder_path)
 
 @folder_router.patch(
-    "/{vault_folder_path:path}", 
-    summary="Move or rename a folder",
+    "/{vault_folder_path:path}",
+    summary="Update Folder",
     response_description='Move or rename the specified folder to the new specified path.',
     response_model=FolderResponse
 )
@@ -64,13 +64,11 @@ async def patch_folder(
 ) -> FolderResponse:
     # If no request model or no fields are provided, return current state
     if not request_model or not request_model.model_dump(exclude_unset=True):
-        return read_folder_to_response(full_folder_path)
+        return get_folder_response(full_folder_path)
         
     # Handle path update if provided
     if request_model.path is not None:
         full_destination_path = validate_destination_path(request_model.path, vault_folder_path)
-        if os.path.exists(full_destination_path):
-            raise HTTPException(status_code=400, detail="Destination folder already exists")
         os.makedirs(os.path.dirname(full_destination_path), exist_ok=True)
         os.rename(full_folder_path, full_destination_path)
-    return read_folder_to_response(full_destination_path)
+    return get_folder_response(full_destination_path)

--- a/app/models.py
+++ b/app/models.py
@@ -20,13 +20,6 @@ class ResourceMetadata(BaseModel):
 class FileCreateRequest(BaseModel):
      content: str = Field(..., description="Content to write to the new file")
 
-class FilePutRequest(BaseModel):
-    content: str = Field(..., description="Content to replace the existing file with")
-
-class FilePatchRequest(BaseModel):
-    path: Optional[str] = Field(None, description="New path to move or rename the file to")
-    content: Optional[str] = Field(None, description="New content to update the file with")
-
 class MetadataPatchRequest(BaseModel):
     path: Optional[str] = Field(None, description="New path to move or rename the file to")
 

--- a/app/models.py
+++ b/app/models.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field
-from typing import Optional, List, Literal
+from typing import Optional, List, Literal, Dict, Any
 from enum import StrEnum
 from datetime import datetime
 
@@ -36,6 +36,7 @@ class FileResponse(ResourceMetadata):
     type: Literal[ResourceType.FILE] = Field(..., description="The type of the entry: 'file'")
     size: int = Field(..., description="Size of the file in bytes")
     content: Optional[str] = Field(None, description="The full content of the file")
+    frontmatter: Optional[Dict[str, Any]] = Field(None, description="The YAML frontmatter of the file")
 
 class FolderResponse(ResourceMetadata):
     type: Literal[ResourceType.FOLDER] = Field(..., description="The type of the entry: 'folder'")

--- a/app/models.py
+++ b/app/models.py
@@ -1,9 +1,7 @@
 from pydantic import BaseModel, Field
-from typing import Optional, Literal, Dict, Any
+from typing import Optional, Literal
 from enum import StrEnum
 from datetime import datetime
-
-# base
 
 class ResourceType(StrEnum):
     FILE = "file"
@@ -14,46 +12,26 @@ class ResourceMetadata(BaseModel):
     path: str = Field(..., description="The full relative path from the vault root")
     created: Optional[datetime] = Field(None, description="The timestamp when the file or folder was created")
     modified: Optional[datetime] = Field(None, description="The timestamp when the file or folder was last modified")
-
-# request
-
-class FileCreateRequest(BaseModel):
-     content: str = Field(..., description="Content to write to the new file")
-
-class MetadataPatchRequest(BaseModel):
-    path: Optional[str] = Field(None, description="New path to move or rename the file to")
-
-class FrontmatterPutRequest(BaseModel):
-    frontmatter: Dict[str, Any] = Field(..., description="Complete frontmatter to replace existing frontmatter")
-
-class FrontmatterPatchRequest(BaseModel):
-    frontmatter: Dict[str, Any] = Field(..., description="Frontmatter updates to merge with existing frontmatter")
-
-class BodyPutRequest(BaseModel):
-    body: str = Field(..., description="Complete body content to replace existing body")
-
-class RawPutRequest(BaseModel):
-    content: str = Field(..., description="Complete raw content to replace existing content")
-
-class FolderPatchRequest(BaseModel):
-    path: Optional[str] = Field(None, description="New path to move or rename the folder to")
-
-# response
-    
-class BaseFileResponse(ResourceMetadata):
+ 
+class FileMetadata(ResourceMetadata):
     type: Literal[ResourceType.FILE] = Field(..., description="The type of the entry: 'file'")
     size: int = Field(..., description="Size of the file in bytes")
     created: datetime = Field(..., description="When the file was created")
     modified: datetime = Field(..., description="When the file was last modified")
 
-class FrontmatterResponse(BaseModel):
-    frontmatter: Optional[Dict[str, Any]] = Field(None, description="The YAML frontmatter of the file")
-
-class BodyResponse(BaseModel):
-    body: str = Field(..., description="The body content of the file without frontmatter")
-
-class ParsedFileResponse(BaseFileResponse, FrontmatterResponse, BodyResponse):
-    pass
-
-class FolderResponse(ResourceMetadata):
+class FolderMetadata(ResourceMetadata):
     type: Literal[ResourceType.FOLDER] = Field(..., description="The type of the entry: 'folder'")
+
+class MarkdownContent(BaseModel):
+    frontmatter: Optional[dict] = Field(None, description="The YAML frontmatter of the file")
+    body: Optional[str] = Field(None, description="The body content of the file without frontmatter")
+
+class MarkdownFile(BaseModel):
+    metadata: FileMetadata = Field(..., description="The metadata of the markdown file")
+    content: MarkdownContent = Field(..., description="The content of the markdown file including frontmatter and body")
+
+class Folder(ResourceMetadata):
+    metadata: FolderMetadata = Field(..., description="The metadata of the folder")
+
+class MetadataPatchRequest(BaseModel):
+    path: Optional[str] = Field(None, description="New path to move or rename the file to")

--- a/app/models.py
+++ b/app/models.py
@@ -8,30 +8,30 @@ class ResourceType(StrEnum):
     FOLDER = "folder"
 
 class ResourceMetadata(BaseModel):
-    name: str = Field(..., description="The name of the file or folder")
-    path: str = Field(..., description="The full relative path from the vault root")
-    created: Optional[datetime] = Field(None, description="The timestamp when the file or folder was created")
-    modified: Optional[datetime] = Field(None, description="The timestamp when the file or folder was last modified")
+    name: str = Field(..., description="Name of the file or folder")
+    path: str = Field(..., description="Full relative path from the vault root")
+    created: Optional[datetime] = Field(None, description="When the file or folder was created")
+    modified: Optional[datetime] = Field(None, description="When the file or folder was last modified")
  
 class FileMetadata(ResourceMetadata):
-    type: Literal[ResourceType.FILE] = Field(..., description="The type of the entry: 'file'")
+    type: Literal[ResourceType.FILE] = Field(..., description="Literal value indicating this is a file")
     size: int = Field(..., description="Size of the file in bytes")
     created: datetime = Field(..., description="When the file was created")
     modified: datetime = Field(..., description="When the file was last modified")
 
 class FolderMetadata(ResourceMetadata):
-    type: Literal[ResourceType.FOLDER] = Field(..., description="The type of the entry: 'folder'")
+    type: Literal[ResourceType.FOLDER] = Field(..., description="Literal value indicating this is a folder")
 
 class MarkdownContent(BaseModel):
-    frontmatter: Optional[dict] = Field(None, description="The YAML frontmatter of the file")
-    body: Optional[str] = Field(None, description="The body content of the file without frontmatter")
+    frontmatter: Optional[dict] = Field(None, description="YAML frontmatter of the file")
+    body: Optional[str] = Field(None, description="Body content of the file without frontmatter")
 
 class MarkdownFile(BaseModel):
-    metadata: FileMetadata = Field(..., description="The metadata of the markdown file")
-    content: MarkdownContent = Field(..., description="The content of the markdown file including frontmatter and body")
+    metadata: FileMetadata = Field(..., description="File metadata including name, path, timestamps, and size")
+    content: MarkdownContent = Field(..., description="Content of the markdown file including frontmatter and body")
 
 class Folder(BaseModel):
-    metadata: FolderMetadata = Field(..., description="The metadata of the folder")
+    metadata: FolderMetadata = Field(..., description="Folder metadata including name, path, and timestamps")
 
-class MetadataPatchRequest(BaseModel):
-    path: Optional[str] = Field(None, description="New path to move or rename the file to")
+class Path(BaseModel):
+    path: Optional[str] = Field(None, description="Target path for moving or renaming a file, relative to the vault root")

--- a/app/models.py
+++ b/app/models.py
@@ -30,7 +30,7 @@ class MarkdownFile(BaseModel):
     metadata: FileMetadata = Field(..., description="The metadata of the markdown file")
     content: MarkdownContent = Field(..., description="The content of the markdown file including frontmatter and body")
 
-class Folder(ResourceMetadata):
+class Folder(BaseModel):
     metadata: FolderMetadata = Field(..., description="The metadata of the folder")
 
 class MetadataPatchRequest(BaseModel):

--- a/app/models.py
+++ b/app/models.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field
-from typing import Optional, List, Literal, Dict, Any
+from typing import Optional, Literal, Dict, Any
 from enum import StrEnum
 from datetime import datetime
 
@@ -27,17 +27,40 @@ class FilePatchRequest(BaseModel):
     path: Optional[str] = Field(None, description="New path to move or rename the file to")
     content: Optional[str] = Field(None, description="New content to update the file with")
 
+class MetadataPatchRequest(BaseModel):
+    path: Optional[str] = Field(None, description="New path to move or rename the file to")
+
+class FrontmatterPutRequest(BaseModel):
+    frontmatter: Dict[str, Any] = Field(..., description="Complete frontmatter to replace existing frontmatter")
+
+class FrontmatterPatchRequest(BaseModel):
+    frontmatter: Dict[str, Any] = Field(..., description="Frontmatter updates to merge with existing frontmatter")
+
+class BodyPutRequest(BaseModel):
+    body: str = Field(..., description="Complete body content to replace existing body")
+
+class RawPutRequest(BaseModel):
+    content: str = Field(..., description="Complete raw content to replace existing content")
+
 class FolderPatchRequest(BaseModel):
     path: Optional[str] = Field(None, description="New path to move or rename the folder to")
 
 # response
     
-class FileResponse(ResourceMetadata):
+class BaseFileResponse(ResourceMetadata):
     type: Literal[ResourceType.FILE] = Field(..., description="The type of the entry: 'file'")
     size: int = Field(..., description="Size of the file in bytes")
-    content: Optional[str] = Field(None, description="The full content of the file")
+    created: datetime = Field(..., description="When the file was created")
+    modified: datetime = Field(..., description="When the file was last modified")
+
+class FrontmatterResponse(BaseModel):
     frontmatter: Optional[Dict[str, Any]] = Field(None, description="The YAML frontmatter of the file")
+
+class BodyResponse(BaseModel):
+    body: str = Field(..., description="The body content of the file without frontmatter")
+
+class ParsedFileResponse(BaseFileResponse, FrontmatterResponse, BodyResponse):
+    pass
 
 class FolderResponse(ResourceMetadata):
     type: Literal[ResourceType.FOLDER] = Field(..., description="The type of the entry: 'folder'")
-    children: Optional[List[FileResponse]] = Field(None, description="List of child markdown files")

--- a/app/path_validation.py
+++ b/app/path_validation.py
@@ -1,11 +1,3 @@
-"""
-Path validation dependencies for FastAPI endpoints.
-
-These validators are designed to be injected into FastAPI endpoints using Depends().
-They handle validation of vault-relative paths and convert them to full system paths,
-ensuring paths are valid, exist (or don't exist) as required, and are within the vault.
-"""
-
 import os
 from fastapi import HTTPException, Request, status
 from fastapi.exceptions import RequestValidationError
@@ -63,7 +55,7 @@ def validate_destination_path(vault_destination_path: str, vault_source_path: Op
         source_full_path = _get_full_path(vault_source_path)
         if os.path.normpath(full_path) == os.path.normpath(source_full_path):
             return full_path
-    if os.path.exists(full_path):
+    if os.path.exists(full_path): # need to also test source path
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Path already exists: {vault_destination_path}")
     return full_path
 

--- a/app/path_validation.py
+++ b/app/path_validation.py
@@ -62,4 +62,4 @@ async def validate_utf8_content(request: Request) -> str:
     try:
         return content.decode('utf-8')
     except UnicodeDecodeError:
-        raise HTTPException(status_code=400, detail="Content must be UTF-8 encoded text")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Content must be UTF-8 encoded text")

--- a/app/path_validation.py
+++ b/app/path_validation.py
@@ -6,32 +6,27 @@ from app.utils import get_vault_path, is_hidden
 import frontmatter
 
 def _get_full_path(vault_relative_path: str) -> str:
-    full_path = os.path.join(get_vault_path(), vault_relative_path)
-    if not os.path.abspath(full_path).startswith(os.path.abspath(get_vault_path())):
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid path")
-    return full_path
+    return os.path.join(get_vault_path(), vault_relative_path)
 
 def _validate_path(
     vault_relative_path: str,
-    path_type: Literal["file", "folder"],
     must_exist: bool = True,
     must_be_markdown: bool = False
 ) -> str:
     full_path = _get_full_path(vault_relative_path)
+
+    if not os.path.abspath(full_path).startswith(os.path.abspath(get_vault_path())):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid path")
     
     if is_hidden(full_path):
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"{path_type.capitalize()} not found: {vault_relative_path}")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Path not found: {vault_relative_path}")
     
-    if must_exist:
-        if not os.path.exists(full_path):
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"{path_type.capitalize()} not found: {vault_relative_path}")
-        if path_type == "file" and not os.path.isfile(full_path):
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Path is not a file: {vault_relative_path}")
-        elif path_type == "folder" and not os.path.isdir(full_path):
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Path is not a folder: {vault_relative_path}")
-    else:
-        if os.path.exists(full_path):
-            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=f"{path_type.capitalize()} already exists: {vault_relative_path}")
+    path_exists = os.path.exists(full_path)
+    
+    if must_exist and not path_exists:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Path not found: {vault_relative_path}")
+    elif not must_exist and path_exists:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=f"Path already exists: {vault_relative_path}")
     
     if must_be_markdown and not full_path.endswith('.md'):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"File must have .md extension: {vault_relative_path}")
@@ -39,26 +34,25 @@ def _validate_path(
     return full_path
 
 def validate_existing_markdown_file(vault_file_path: str) -> str:
-    return _validate_path(vault_file_path, "file", must_exist=True, must_be_markdown=True)
+    full_path = _validate_path(vault_file_path, must_exist=True, must_be_markdown=True)
+    if not os.path.isfile(full_path):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Path is not a file: {vault_file_path}")
+    return full_path
 
 def validate_existing_folder(vault_folder_path: str) -> str:
-    return _validate_path(vault_folder_path, "folder", must_exist=True)
+    full_path = _validate_path(vault_folder_path, must_exist=True)
+    if not os.path.isdir(full_path):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Path is not a folder: {vault_folder_path}")
+    return full_path
 
 def validate_new_markdown_file(vault_file_path: str) -> str:
-    return _validate_path(vault_file_path, "file", must_exist=False, must_be_markdown=True)
+    return _validate_path(vault_file_path, must_exist=False, must_be_markdown=True)
 
 def validate_new_folder(vault_folder_path: str) -> str:
-    return _validate_path(vault_folder_path, "folder", must_exist=False)
+    return _validate_path(vault_folder_path, must_exist=False)
 
 def validate_destination_path(vault_destination_path: str, vault_source_path: Optional[str] = None) -> str:
-    full_path = _get_full_path(vault_destination_path)
-    if vault_source_path:
-        source_full_path = _get_full_path(vault_source_path)
-        if os.path.normpath(full_path) == os.path.normpath(source_full_path):
-            return full_path
-    if os.path.exists(full_path): # need to also test source path
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=f"Path already exists: {vault_destination_path}")
-    return full_path
+    return _validate_path(vault_destination_path, must_exist=False)
 
 async def validation_exception_handler(request: Request, exc: RequestValidationError):
     return HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail={"errors": exc.errors()})
@@ -69,15 +63,3 @@ async def validate_utf8_content(request: Request) -> str:
         return content.decode('utf-8')
     except UnicodeDecodeError:
         raise HTTPException(status_code=400, detail="Content must be UTF-8 encoded text")
-
-async def validate_markdown_content(request: Request) -> str:
-    content = await request.body()
-    try:
-        decoded_content = content.decode('utf-8')
-        if frontmatter.checks(decoded_content):
-            frontmatter.loads(decoded_content)
-        return decoded_content
-    except UnicodeDecodeError:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Content must be UTF-8 encoded text")
-    except Exception as e:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Content must be valid markdown format: {str(e)}") 

--- a/app/path_validation.py
+++ b/app/path_validation.py
@@ -30,7 +30,7 @@ def _validate_path(
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Path is not a folder: {vault_relative_path}")
     else:
         if os.path.exists(full_path):
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"{path_type.capitalize()} already exists: {vault_relative_path}")
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=f"{path_type.capitalize()} already exists: {vault_relative_path}")
     
     if must_be_markdown and not full_path.endswith('.md'):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"File must have .md extension: {vault_relative_path}")
@@ -56,7 +56,7 @@ def validate_destination_path(vault_destination_path: str, vault_source_path: Op
         if os.path.normpath(full_path) == os.path.normpath(source_full_path):
             return full_path
     if os.path.exists(full_path): # need to also test source path
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Path already exists: {vault_destination_path}")
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=f"Path already exists: {vault_destination_path}")
     return full_path
 
 async def validation_exception_handler(request: Request, exc: RequestValidationError):

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,15 +1,15 @@
 import os
-from fastapi import HTTPException, status
+from fastapi import Response
 from pathlib import Path
 from datetime import datetime
-from app.models import FileResponse, ResourceType, FolderResponse
-from typing import Literal
 import frontmatter
+from typing import Optional
+from app.models import ResourceType, FolderResponse, ParsedFileResponse, BaseFileResponse, FrontmatterResponse, BodyResponse
+
+# Core Utilities
 
 def get_vault_path() -> str:
     path = os.getenv("OBSIDIAN_API_VAULT_PATH")
-    if not path:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="OBSIDIAN_API_VAULT_PATH environment variable must be set")
     return path
 
 def is_hidden(path: str) -> bool:
@@ -23,18 +23,95 @@ def is_hidden(path: str) -> bool:
             
     return False
 
-def walk_files() -> list[FileResponse]:
-    vault_path = get_vault_path()
-    items = []
+# Component Generators
+
+def get_raw_content(full_file_path: str) -> str:
+    with open(full_file_path, 'r', encoding='utf-8') as f:
+        return f.read()
+
+def get_parsed_content(content: str) -> tuple[str, Optional[dict]]:
+    post = frontmatter.loads(content)
+    return post.content, post.metadata if post.metadata else None
+
+def get_file_metadata(full_file_path: str) -> dict:
+    path = os.path.relpath(full_file_path, get_vault_path())
+    stats = os.stat(full_file_path)
     
-    for root, _, files in os.walk(vault_path):
-        for file in files:
-            if file.endswith('.md'):
-                full_file_path = os.path.join(root, file)
-                if not is_hidden(full_file_path):
-                    items.append(read_file_to_response(full_file_path))
+    return {
+        "name": os.path.basename(path),
+        "path": path,
+        "type": ResourceType.FILE,
+        "size": stats.st_size,
+        "created": datetime.fromtimestamp(stats.st_ctime),
+        "modified": datetime.fromtimestamp(stats.st_mtime)
+    }
+
+# Response Generators
+
+def get_raw_response(full_file_path: str) -> Response:
+    content = get_raw_content(full_file_path)
+    return Response(content=content, media_type="text/plain")
+
+def get_file_response(full_file_path: str) -> ParsedFileResponse:
+    metadata = get_file_metadata(full_file_path)
+    content = get_raw_content(full_file_path)
+    body, frontmatter_data = get_parsed_content(content)
+    return ParsedFileResponse(
+        **metadata,
+        body=body,
+        frontmatter=frontmatter_data
+    )
+
+def get_file_metadata_response(full_file_path: str) -> BaseFileResponse:
+    return BaseFileResponse(**get_file_metadata(full_file_path))
+
+def get_file_frontmatter_response(full_file_path: str) -> FrontmatterResponse:
+    content = get_raw_content(full_file_path)
+    _, frontmatter_data = get_parsed_content(content)
+    return FrontmatterResponse(frontmatter=frontmatter_data)
+
+def get_file_body_response(full_file_path: str) -> BodyResponse:
+    content = get_raw_content(full_file_path)
+    body, _ = get_parsed_content(content)
+    return BodyResponse(body=body)
+
+def get_folder_response(full_folder_path: str) -> FolderResponse:
+    path = os.path.relpath(full_folder_path, get_vault_path())
+    stats = os.stat(full_folder_path)
     
-    return items
+    return FolderResponse(
+        name=os.path.basename(path),
+        path=path,
+        type=ResourceType.FOLDER,
+        size=stats.st_size,
+        created=datetime.fromtimestamp(stats.st_ctime),
+        modified=datetime.fromtimestamp(stats.st_mtime)
+    )
+
+def update_file_content(full_file_path: str, content: str) -> None:
+    with open(full_file_path, 'w', encoding='utf-8') as f:
+        f.write(content)
+
+def update_frontmatter(full_file_path: str, frontmatter_data: dict) -> None:
+    content = get_raw_content(full_file_path)
+    post = frontmatter.loads(content)
+    post.metadata = frontmatter_data
+    update_file_content(full_file_path, frontmatter.dumps(post))
+
+def update_body(full_file_path: str, body: str) -> None:
+    content = get_raw_content(full_file_path)
+    post = frontmatter.loads(content)
+    post.content = body
+    update_file_content(full_file_path, frontmatter.dumps(post))
+
+def merge_frontmatter(full_file_path: str, frontmatter_updates: dict) -> None:
+    content = get_raw_content(full_file_path)
+    post = frontmatter.loads(content)
+    current_metadata = post.metadata or {}
+    post.metadata = {**current_metadata, **frontmatter_updates}
+    update_file_content(full_file_path, frontmatter.dumps(post))
+
+# Walk Helpers
 
 def walk_folders() -> list[FolderResponse]:
     vault_path = get_vault_path()
@@ -44,51 +121,19 @@ def walk_folders() -> list[FolderResponse]:
         for dir_name in dirs:
             full_dir_path = os.path.join(root, dir_name)
             if not is_hidden(full_dir_path):
-                items.append(read_folder_to_response(full_dir_path, include_children=False))
+                items.append(get_folder_response(full_dir_path))
     
     return items
 
-def read_file_to_response(full_file_path: str) -> FileResponse:
-    path = os.path.relpath(full_file_path, get_vault_path())
-        
-    with open(full_file_path, 'r', encoding='utf-8') as f:
-        note = frontmatter.load(f)
-        content = note.content
-        frontmatter_data = note.metadata if note.metadata else None
+def walk_files() -> list[ParsedFileResponse]:
+    vault_path = get_vault_path()
+    items = []
     
-    stats = os.stat(full_file_path)
+    for root, _, files in os.walk(vault_path):
+        for file in files:
+            if file.endswith('.md'):
+                full_file_path = os.path.join(root, file)
+                if not is_hidden(full_file_path):
+                    items.append(get_file_response(full_file_path))
     
-    return FileResponse(
-        name=os.path.basename(path),
-        path=path,
-        type=ResourceType.FILE,
-        size=stats.st_size,
-        content=content,
-        frontmatter=frontmatter_data,
-        created=datetime.fromtimestamp(stats.st_ctime),
-        modified=datetime.fromtimestamp(stats.st_mtime)
-    )
-
-def read_folder_to_response(full_folder_path: str, include_children: bool = True) -> FolderResponse:
-    path = os.path.relpath(full_folder_path, get_vault_path())
-        
-    stats = os.stat(full_folder_path)
-    children = []
-    
-    if include_children:
-        for root, _, filenames in os.walk(full_folder_path):
-            for filename in sorted(filenames):
-                if filename.endswith('.md'):
-                    full_file_path = os.path.join(root, filename)
-                    children.append(read_file_to_response(full_file_path))
-        children.sort(key=lambda x: x.path)
-    
-    return FolderResponse(
-        name=os.path.basename(path),
-        path=path,
-        type=ResourceType.FOLDER,
-        size=stats.st_size,
-        created=datetime.fromtimestamp(stats.st_ctime),
-        modified=datetime.fromtimestamp(stats.st_mtime),
-        children=children if include_children else None
-    )
+    return items

--- a/app/utils.py
+++ b/app/utils.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from datetime import datetime
 from app.models import FileResponse, ResourceType, FolderResponse
 from typing import Literal
+import frontmatter
 
 def get_vault_path() -> str:
     path = os.getenv("OBSIDIAN_API_VAULT_PATH")
@@ -51,7 +52,9 @@ def read_file_to_response(full_file_path: str) -> FileResponse:
     path = os.path.relpath(full_file_path, get_vault_path())
         
     with open(full_file_path, 'r', encoding='utf-8') as f:
-        content = f.read()
+        note = frontmatter.load(f)
+        content = note.content
+        frontmatter_data = note.metadata if note.metadata else None
     
     stats = os.stat(full_file_path)
     
@@ -61,6 +64,7 @@ def read_file_to_response(full_file_path: str) -> FileResponse:
         type=ResourceType.FILE,
         size=stats.st_size,
         content=content,
+        frontmatter=frontmatter_data,
         created=datetime.fromtimestamp(stats.st_ctime),
         modified=datetime.fromtimestamp(stats.st_mtime)
     )

--- a/app/utils.py
+++ b/app/utils.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from datetime import datetime
 import frontmatter
 from typing import Optional
-from app.models import ResourceType, Folder, MarkdownFile, FileMetadata, MarkdownContent
+from app.models import ResourceType, Folder, MarkdownFile, FileMetadata, MarkdownContent, FolderMetadata
 
 # Core Utilities
 
@@ -85,10 +85,10 @@ async def write_markdown_file(full_file_path: str, file_frontmatter: Optional[di
 # Response Generators
 
 async def get_markdown_file_model(full_file_path: str) -> MarkdownFile:
-    metadata = await read_stats(full_file_path)
+    stats = await read_stats(full_file_path)
     body, frontmatter_data = await read_markdown_file(full_file_path)
     return MarkdownFile(
-        metadata=FileMetadata(**metadata),
+        metadata=FileMetadata(**stats),
         content=MarkdownContent(
             body=body,
             frontmatter=frontmatter_data
@@ -97,7 +97,9 @@ async def get_markdown_file_model(full_file_path: str) -> MarkdownFile:
 
 async def get_folder_model(full_folder_path: str) -> Folder:
     stats = await read_stats(full_folder_path)
-    return Folder(**stats)
+    return Folder(
+        metadata=FolderMetadata(**stats)
+    )
 
 # Walk Helpers
 

--- a/obsidian-api.postman_collection.json
+++ b/obsidian-api.postman_collection.json
@@ -71,7 +71,8 @@
                   "type": "file",
                   "name": "test1.md",
                   "path": "Notes/test1.md",
-                  "content": "# Test File 1",
+                  "body": "# Test File 1",
+                  "frontmatter": null,
                   "size": 12,
                   "created": "2024-03-20T10:00:00Z",
                   "modified": "2024-03-20T10:00:00Z"
@@ -81,7 +82,7 @@
           ]
         },
         {
-          "name": "Get File Contents",
+          "name": "Get Structured File Content",
           "request": {
             "method": "GET",
             "header": [],
@@ -125,27 +126,49 @@
                 "type": "file",
                 "name": "test1.md",
                 "path": "Notes/test1.md",
-                "content": "# Test File 1",
+                "body": "# Test File 1",
+                "frontmatter": null,
                 "size": 12,
                 "created": "2024-03-20T10:00:00Z",
                 "modified": "2024-03-20T10:00:00Z"
               }
-            },
+            }
+          ]
+        },
+        {
+          "name": "Get Raw File Content",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/files/{{path}}/raw",
+              "host": ["{{base_url}}"],
+              "path": ["files", "{{path}}", "raw"],
+              "variable": [
+                {
+                  "key": "path",
+                  "value": "path/to/file.md",
+                  "description": "Path to the markdown file"
+                }
+              ]
+            }
+          },
+          "response": [
             {
-              "name": "Not Found",
+              "name": "Success",
               "originalRequest": {
                 "method": "GET",
                 "header": [],
                 "url": {
-                  "raw": "http://localhost:8000/files/nonexistent.md",
+                  "raw": "http://localhost:8000/files/Notes/test1.md/raw",
                   "protocol": "http",
                   "host": ["localhost"],
                   "port": "8000",
-                  "path": ["files", "nonexistent.md"]
+                  "path": ["files", "Notes", "test1.md", "raw"]
                 }
               },
-              "status": "Not Found",
-              "code": 404,
+              "status": "OK",
+              "code": 200,
               "_postman_previewlanguage": "json",
               "header": [
                 {
@@ -154,7 +177,159 @@
                 }
               ],
               "body": {
-                "detail": "File not found"
+                "type": "file",
+                "name": "test1.md",
+                "path": "Notes/test1.md",
+                "content": "# Test File 1",
+                "size": 12,
+                "created": "2024-03-20T10:00:00Z",
+                "modified": "2024-03-20T10:00:00Z"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Get File Metadata",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/files/{{path}}/metadata",
+              "host": ["{{base_url}}"],
+              "path": ["files", "{{path}}", "metadata"],
+              "variable": [
+                {
+                  "key": "path",
+                  "value": "path/to/file.md",
+                  "description": "Path to the markdown file"
+                }
+              ]
+            }
+          },
+          "response": [
+            {
+              "name": "Success",
+              "originalRequest": {
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "http://localhost:8000/files/Notes/test1.md/metadata",
+                  "protocol": "http",
+                  "host": ["localhost"],
+                  "port": "8000",
+                  "path": ["files", "Notes", "test1.md", "metadata"]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": {
+                "type": "file",
+                "name": "test1.md",
+                "path": "Notes/test1.md",
+                "size": 12,
+                "created": "2024-03-20T10:00:00Z",
+                "modified": "2024-03-20T10:00:00Z"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Get File Frontmatter",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/files/{{path}}/frontmatter",
+              "host": ["{{base_url}}"],
+              "path": ["files", "{{path}}", "frontmatter"],
+              "variable": [
+                {
+                  "key": "path",
+                  "value": "path/to/file.md",
+                  "description": "Path to the markdown file"
+                }
+              ]
+            }
+          },
+          "response": [
+            {
+              "name": "Success",
+              "originalRequest": {
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "http://localhost:8000/files/Notes/test1.md/frontmatter",
+                  "protocol": "http",
+                  "host": ["localhost"],
+                  "port": "8000",
+                  "path": ["files", "Notes", "test1.md", "frontmatter"]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": {
+                "frontmatter": null
+              }
+            }
+          ]
+        },
+        {
+          "name": "Get File Body",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/files/{{path}}/body",
+              "host": ["{{base_url}}"],
+              "path": ["files", "{{path}}", "body"],
+              "variable": [
+                {
+                  "key": "path",
+                  "value": "path/to/file.md",
+                  "description": "Path to the markdown file"
+                }
+              ]
+            }
+          },
+          "response": [
+            {
+              "name": "Success",
+              "originalRequest": {
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "http://localhost:8000/files/Notes/test1.md/body",
+                  "protocol": "http",
+                  "host": ["localhost"],
+                  "port": "8000",
+                  "path": ["files", "Notes", "test1.md", "body"]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": {
+                "body": "# Test File 1"
               }
             }
           ]

--- a/obsidian-api.postman_collection.json
+++ b/obsidian-api.postman_collection.json
@@ -33,7 +33,8 @@
       "name": "Files",
       "item": [
         {
-          "name": "List All Files",
+          "name": "List Files",
+          "description": "List all markdown files in your vault with their metadata, including path, size, and modification dates.",
           "request": {
             "method": "GET",
             "header": [],
@@ -82,7 +83,8 @@
           ]
         },
         {
-          "name": "Get Structured File Content",
+          "name": "Get File",
+          "description": "Get the complete file representation including metadata, YAML frontmatter, and markdown body content.",
           "request": {
             "method": "GET",
             "header": [],
@@ -136,7 +138,8 @@
           ]
         },
         {
-          "name": "Create File",
+          "name": "Create File (Structured)",
+          "description": "Create a new markdown file at the specified path using a JSON object with 'frontmatter' (YAML object) and 'body' (markdown string) fields.",
           "request": {
             "method": "POST",
             "header": [
@@ -147,7 +150,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"content\": \"# New File\\n\\nThis is a new markdown file.\"\n}"
+              "raw": "{\n    \"frontmatter\": {\n        \"title\": \"New Note\",\n        \"tags\": [\"note\", \"test\"]\n    },\n    \"body\": \"# New File\\n\\nThis is a new markdown file.\"\n}"
             },
             "url": {
               "raw": "{{base_url}}/files/{{path}}",
@@ -175,7 +178,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"content\": \"# New File\\n\\nThis is a new markdown file.\"\n}"
+                  "raw": "{\n    \"frontmatter\": {\n        \"title\": \"New Note\",\n        \"tags\": [\"note\", \"test\"]\n    },\n    \"body\": \"# New File\\n\\nThis is a new markdown file.\"\n}"
                 },
                 "url": {
                   "raw": "http://localhost:8000/files/Notes/newfile.md",
@@ -199,7 +202,10 @@
                 "name": "newfile.md",
                 "path": "Notes/newfile.md",
                 "body": "# New File\n\nThis is a new markdown file.",
-                "frontmatter": null,
+                "frontmatter": {
+                  "title": "New Note",
+                  "tags": ["note", "test"]
+                },
                 "size": 35,
                 "created": "2024-03-20T10:00:00Z",
                 "modified": "2024-03-20T10:00:00Z"
@@ -208,7 +214,84 @@
           ]
         },
         {
-          "name": "Get Raw File Content",
+          "name": "Create File (Raw)",
+          "description": "Create a new markdown file at the specified path with raw text content. The content should include YAML frontmatter (between --- markers) followed by markdown body content.",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "text/markdown"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "---\ntitle: New Raw Note\ntags: [note, test]\n---\n\n# New Raw File\n\nThis is a new raw markdown file."
+            },
+            "url": {
+              "raw": "{{base_url}}/files/{{path}}/raw",
+              "host": ["{{base_url}}"],
+              "path": ["files", "{{path}}", "raw"],
+              "variable": [
+                {
+                  "key": "path",
+                  "value": "path/to/newfile.md",
+                  "description": "Path where the new file should be created"
+                }
+              ]
+            }
+          },
+          "response": [
+            {
+              "name": "Success",
+              "originalRequest": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "text/markdown"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "---\ntitle: New Raw Note\ntags: [note, test]\n---\n\n# New Raw File\n\nThis is a new raw markdown file."
+                },
+                "url": {
+                  "raw": "http://localhost:8000/files/Notes/newfile.md/raw",
+                  "protocol": "http",
+                  "host": ["localhost"],
+                  "port": "8000",
+                  "path": ["files", "Notes", "newfile.md", "raw"]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": {
+                "type": "file",
+                "name": "newfile.md",
+                "path": "Notes/newfile.md",
+                "body": "# New Raw File\n\nThis is a new raw markdown file.",
+                "frontmatter": {
+                  "title": "New Raw Note",
+                  "tags": ["note", "test"]
+                },
+                "size": 45,
+                "created": "2024-03-20T10:00:00Z",
+                "modified": "2024-03-20T10:00:00Z"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Get Raw File",
+          "description": "Get the raw contents of the markdown file at the specified path, including frontmatter and body content exactly as stored.",
           "request": {
             "method": "GET",
             "header": [],
@@ -253,7 +336,8 @@
           ]
         },
         {
-          "name": "Update Raw File Content",
+          "name": "Replace Raw Content",
+          "description": "Replace the entire raw content of the file. The content should include YAML frontmatter (between --- markers) followed by markdown body content.",
           "request": {
             "method": "PUT",
             "header": [
@@ -326,6 +410,7 @@
         },
         {
           "name": "Get File Body",
+          "description": "Get the markdown body content of the file, excluding the frontmatter section.",
           "request": {
             "method": "GET",
             "header": [],
@@ -372,7 +457,8 @@
           ]
         },
         {
-          "name": "Update File Body",
+          "name": "Replace Body",
+          "description": "Replace the entire markdown body content of the file, preserving the frontmatter.",
           "request": {
             "method": "PUT",
             "header": [
@@ -438,6 +524,7 @@
         },
         {
           "name": "Get File Frontmatter",
+          "description": "Get the YAML frontmatter of the file as a JSON object.",
           "request": {
             "method": "GET",
             "header": [],
@@ -484,7 +571,8 @@
           ]
         },
         {
-          "name": "Update File Frontmatter",
+          "name": "Replace Frontmatter",
+          "description": "Replace the entire YAML frontmatter of the file with a new JSON object containing frontmatter data.",
           "request": {
             "method": "PUT",
             "header": [
@@ -552,7 +640,8 @@
           ]
         },
         {
-          "name": "Patch File Frontmatter",
+          "name": "Merge Frontmatter",
+          "description": "Merge a new JSON object containing frontmatter data with the existing YAML frontmatter.",
           "request": {
             "method": "PATCH",
             "header": [
@@ -621,6 +710,7 @@
         },
         {
           "name": "Get File Metadata",
+          "description": "Get the file's metadata including name, path, size, creation date, and last modification date.",
           "request": {
             "method": "GET",
             "header": [],
@@ -672,7 +762,8 @@
           ]
         },
         {
-          "name": "Patch File Metadata",
+          "name": "Merge File Metadata",
+          "description": "Merge new metadata with existing file metadata, including moving/renaming the file to a new path within the vault.",
           "request": {
             "method": "PATCH",
             "header": [

--- a/obsidian-api.postman_collection.json
+++ b/obsidian-api.postman_collection.json
@@ -136,205 +136,6 @@
           ]
         },
         {
-          "name": "Get Raw File Content",
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{base_url}}/files/{{path}}/raw",
-              "host": ["{{base_url}}"],
-              "path": ["files", "{{path}}", "raw"],
-              "variable": [
-                {
-                  "key": "path",
-                  "value": "path/to/file.md",
-                  "description": "Path to the markdown file"
-                }
-              ]
-            }
-          },
-          "response": [
-            {
-              "name": "Success",
-              "originalRequest": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "http://localhost:8000/files/Notes/test1.md/raw",
-                  "protocol": "http",
-                  "host": ["localhost"],
-                  "port": "8000",
-                  "path": ["files", "Notes", "test1.md", "raw"]
-                }
-              },
-              "status": "OK",
-              "code": 200,
-              "_postman_previewlanguage": "json",
-              "header": [
-                {
-                  "key": "Content-Type",
-                  "value": "application/json"
-                }
-              ],
-              "body": {
-                "type": "file",
-                "name": "test1.md",
-                "path": "Notes/test1.md",
-                "content": "# Test File 1",
-                "size": 12,
-                "created": "2024-03-20T10:00:00Z",
-                "modified": "2024-03-20T10:00:00Z"
-              }
-            }
-          ]
-        },
-        {
-          "name": "Get File Metadata",
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{base_url}}/files/{{path}}/metadata",
-              "host": ["{{base_url}}"],
-              "path": ["files", "{{path}}", "metadata"],
-              "variable": [
-                {
-                  "key": "path",
-                  "value": "path/to/file.md",
-                  "description": "Path to the markdown file"
-                }
-              ]
-            }
-          },
-          "response": [
-            {
-              "name": "Success",
-              "originalRequest": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "http://localhost:8000/files/Notes/test1.md/metadata",
-                  "protocol": "http",
-                  "host": ["localhost"],
-                  "port": "8000",
-                  "path": ["files", "Notes", "test1.md", "metadata"]
-                }
-              },
-              "status": "OK",
-              "code": 200,
-              "_postman_previewlanguage": "json",
-              "header": [
-                {
-                  "key": "Content-Type",
-                  "value": "application/json"
-                }
-              ],
-              "body": {
-                "type": "file",
-                "name": "test1.md",
-                "path": "Notes/test1.md",
-                "size": 12,
-                "created": "2024-03-20T10:00:00Z",
-                "modified": "2024-03-20T10:00:00Z"
-              }
-            }
-          ]
-        },
-        {
-          "name": "Get File Frontmatter",
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{base_url}}/files/{{path}}/frontmatter",
-              "host": ["{{base_url}}"],
-              "path": ["files", "{{path}}", "frontmatter"],
-              "variable": [
-                {
-                  "key": "path",
-                  "value": "path/to/file.md",
-                  "description": "Path to the markdown file"
-                }
-              ]
-            }
-          },
-          "response": [
-            {
-              "name": "Success",
-              "originalRequest": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "http://localhost:8000/files/Notes/test1.md/frontmatter",
-                  "protocol": "http",
-                  "host": ["localhost"],
-                  "port": "8000",
-                  "path": ["files", "Notes", "test1.md", "frontmatter"]
-                }
-              },
-              "status": "OK",
-              "code": 200,
-              "_postman_previewlanguage": "json",
-              "header": [
-                {
-                  "key": "Content-Type",
-                  "value": "application/json"
-                }
-              ],
-              "body": {
-                "frontmatter": null
-              }
-            }
-          ]
-        },
-        {
-          "name": "Get File Body",
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{base_url}}/files/{{path}}/body",
-              "host": ["{{base_url}}"],
-              "path": ["files", "{{path}}", "body"],
-              "variable": [
-                {
-                  "key": "path",
-                  "value": "path/to/file.md",
-                  "description": "Path to the markdown file"
-                }
-              ]
-            }
-          },
-          "response": [
-            {
-              "name": "Success",
-              "originalRequest": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "http://localhost:8000/files/Notes/test1.md/body",
-                  "protocol": "http",
-                  "host": ["localhost"],
-                  "port": "8000",
-                  "path": ["files", "Notes", "test1.md", "body"]
-                }
-              },
-              "status": "OK",
-              "code": 200,
-              "_postman_previewlanguage": "json",
-              "header": [
-                {
-                  "key": "Content-Type",
-                  "value": "application/json"
-                }
-              ],
-              "body": {
-                "body": "# Test File 1"
-              }
-            }
-          ]
-        },
-        {
           "name": "Create File",
           "request": {
             "method": "POST",
@@ -397,72 +198,29 @@
                 "type": "file",
                 "name": "newfile.md",
                 "path": "Notes/newfile.md",
-                "content": "# New File\n\nThis is a new markdown file.",
+                "body": "# New File\n\nThis is a new markdown file.",
+                "frontmatter": null,
                 "size": 35,
                 "created": "2024-03-20T10:00:00Z",
                 "modified": "2024-03-20T10:00:00Z"
-              }
-            },
-            {
-              "name": "Bad Request",
-              "originalRequest": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "text/plain"
-                  }
-                ],
-                "body": {
-                  "mode": "raw",
-                  "raw": ""
-                },
-                "url": {
-                  "raw": "http://localhost:8000/files/Notes/test1.md",
-                  "protocol": "http",
-                  "host": ["localhost"],
-                  "port": "8000",
-                  "path": ["files", "Notes", "test1.md"]
-                }
-              },
-              "status": "Bad Request",
-              "code": 400,
-              "_postman_previewlanguage": "json",
-              "header": [
-                {
-                  "key": "Content-Type",
-                  "value": "application/json"
-                }
-              ],
-              "body": {
-                "detail": "Invalid request body"
               }
             }
           ]
         },
         {
-          "name": "Partial Update File",
+          "name": "Get Raw File Content",
           "request": {
-            "method": "PATCH",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n    \"path\": \"new/path/to/file.md\",\n    \"content\": \"# Updated File\\n\\nThis is the updated content.\"\n}"
-            },
+            "method": "GET",
+            "header": [],
             "url": {
-              "raw": "{{base_url}}/files/{{path}}",
+              "raw": "{{base_url}}/files/{{path}}/raw",
               "host": ["{{base_url}}"],
-              "path": ["files", "{{path}}"],
+              "path": ["files", "{{path}}", "raw"],
               "variable": [
                 {
                   "key": "path",
-                  "value": "current/path/to/file.md",
-                  "description": "Current path of the file"
+                  "value": "path/to/file.md",
+                  "description": "Path to the markdown file"
                 }
               ]
             }
@@ -471,83 +229,31 @@
             {
               "name": "Success",
               "originalRequest": {
-                "method": "PATCH",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n    \"path\": \"Notes/moved.md\",\n    \"content\": \"# Updated File\\n\\nThis is the updated content.\"\n}"
-                },
+                "method": "GET",
+                "header": [],
                 "url": {
-                  "raw": "http://localhost:8000/files/Notes/test1.md",
+                  "raw": "http://localhost:8000/files/Notes/test1.md/raw",
                   "protocol": "http",
                   "host": ["localhost"],
                   "port": "8000",
-                  "path": ["files", "Notes", "test1.md"]
+                  "path": ["files", "Notes", "test1.md", "raw"]
                 }
               },
               "status": "OK",
               "code": 200,
-              "_postman_previewlanguage": "json",
+              "_postman_previewlanguage": "text",
               "header": [
                 {
                   "key": "Content-Type",
-                  "value": "application/json"
+                  "value": "text/markdown"
                 }
               ],
-              "body": {
-                "type": "file",
-                "name": "moved.md",
-                "path": "Notes/moved.md",
-                "content": "# Updated File\n\nThis is the updated content.",
-                "size": 40,
-                "created": "2024-03-20T10:00:00Z",
-                "modified": "2024-03-20T10:00:00Z"
-              }
-            },
-            {
-              "name": "Bad Request",
-              "originalRequest": {
-                "method": "PATCH",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n    \"path\": \"Notes/test1.md\"\n}"
-                },
-                "url": {
-                  "raw": "http://localhost:8000/files/Notes/test2.md",
-                  "protocol": "http",
-                  "host": ["localhost"],
-                  "port": "8000",
-                  "path": ["files", "Notes", "test2.md"]
-                }
-              },
-              "status": "Bad Request",
-              "code": 400,
-              "_postman_previewlanguage": "json",
-              "header": [
-                {
-                  "key": "Content-Type",
-                  "value": "application/json"
-                }
-              ],
-              "body": {
-                "detail": "Destination file already exists"
-              }
+              "body": "# Test File 1"
             }
           ]
         },
         {
-          "name": "Full Update File",
+          "name": "Update Raw File Content",
           "request": {
             "method": "PUT",
             "header": [
@@ -558,17 +264,17 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"content\": \"# Updated File\\n\\nThis is the updated content.\"\n}"
+              "raw": "{\n    \"content\": \"# Updated Raw Content\\n\\nThis is the updated raw content.\"\n}"
             },
             "url": {
-              "raw": "{{base_url}}/files/{{path}}",
+              "raw": "{{base_url}}/files/{{path}}/raw",
               "host": ["{{base_url}}"],
-              "path": ["files", "{{path}}"],
+              "path": ["files", "{{path}}", "raw"],
               "variable": [
                 {
                   "key": "path",
                   "value": "path/to/file.md",
-                  "description": "Path of the file to update"
+                  "description": "Path to the markdown file"
                 }
               ]
             }
@@ -586,14 +292,14 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"content\": \"# Updated File\\n\\nThis is the updated content.\"\n}"
+                  "raw": "{\n    \"content\": \"# Updated Raw Content\\n\\nThis is the updated raw content.\"\n}"
                 },
                 "url": {
-                  "raw": "http://localhost:8000/files/Notes/test1.md",
+                  "raw": "http://localhost:8000/files/Notes/test1.md/raw",
                   "protocol": "http",
                   "host": ["localhost"],
                   "port": "8000",
-                  "path": ["files", "Notes", "test1.md"]
+                  "path": ["files", "Notes", "test1.md", "raw"]
                 }
               },
               "status": "OK",
@@ -609,8 +315,426 @@
                 "type": "file",
                 "name": "test1.md",
                 "path": "Notes/test1.md",
-                "content": "# Updated File\n\nThis is the updated content.",
-                "size": 40,
+                "body": "# Updated Raw Content\n\nThis is the updated raw content.",
+                "frontmatter": null,
+                "size": 45,
+                "created": "2024-03-20T10:00:00Z",
+                "modified": "2024-03-20T10:00:00Z"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Get File Body",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/files/{{path}}/body",
+              "host": ["{{base_url}}"],
+              "path": ["files", "{{path}}", "body"],
+              "variable": [
+                {
+                  "key": "path",
+                  "value": "path/to/file.md",
+                  "description": "Path to the markdown file"
+                }
+              ]
+            }
+          },
+          "response": [
+            {
+              "name": "Success",
+              "originalRequest": {
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "http://localhost:8000/files/Notes/test1.md/body",
+                  "protocol": "http",
+                  "host": ["localhost"],
+                  "port": "8000",
+                  "path": ["files", "Notes", "test1.md", "body"]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": {
+                "body": "# Test File 1"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Update File Body",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"body\": \"# Updated Body\\n\\nThis is the updated body content.\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/files/{{path}}/body",
+              "host": ["{{base_url}}"],
+              "path": ["files", "{{path}}", "body"],
+              "variable": [
+                {
+                  "key": "path",
+                  "value": "path/to/file.md",
+                  "description": "Path to the markdown file"
+                }
+              ]
+            }
+          },
+          "response": [
+            {
+              "name": "Success",
+              "originalRequest": {
+                "method": "PUT",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"body\": \"# Updated Body\\n\\nThis is the updated body content.\"\n}"
+                },
+                "url": {
+                  "raw": "http://localhost:8000/files/Notes/test1.md/body",
+                  "protocol": "http",
+                  "host": ["localhost"],
+                  "port": "8000",
+                  "path": ["files", "Notes", "test1.md", "body"]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": {
+                "body": "# Updated Body\n\nThis is the updated body content."
+              }
+            }
+          ]
+        },
+        {
+          "name": "Get File Frontmatter",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/files/{{path}}/frontmatter",
+              "host": ["{{base_url}}"],
+              "path": ["files", "{{path}}", "frontmatter"],
+              "variable": [
+                {
+                  "key": "path",
+                  "value": "path/to/file.md",
+                  "description": "Path to the markdown file"
+                }
+              ]
+            }
+          },
+          "response": [
+            {
+              "name": "Success",
+              "originalRequest": {
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "http://localhost:8000/files/Notes/test1.md/frontmatter",
+                  "protocol": "http",
+                  "host": ["localhost"],
+                  "port": "8000",
+                  "path": ["files", "Notes", "test1.md", "frontmatter"]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": {
+                "frontmatter": null
+              }
+            }
+          ]
+        },
+        {
+          "name": "Update File Frontmatter",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"frontmatter\": {\n        \"title\": \"Updated Title\",\n        \"tags\": [\"updated\", \"test\"]\n    }\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/files/{{path}}/frontmatter",
+              "host": ["{{base_url}}"],
+              "path": ["files", "{{path}}", "frontmatter"],
+              "variable": [
+                {
+                  "key": "path",
+                  "value": "path/to/file.md",
+                  "description": "Path to the markdown file"
+                }
+              ]
+            }
+          },
+          "response": [
+            {
+              "name": "Success",
+              "originalRequest": {
+                "method": "PUT",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"frontmatter\": {\n        \"title\": \"Updated Title\",\n        \"tags\": [\"updated\", \"test\"]\n    }\n}"
+                },
+                "url": {
+                  "raw": "http://localhost:8000/files/Notes/test1.md/frontmatter",
+                  "protocol": "http",
+                  "host": ["localhost"],
+                  "port": "8000",
+                  "path": ["files", "Notes", "test1.md", "frontmatter"]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": {
+                "frontmatter": {
+                  "title": "Updated Title",
+                  "tags": ["updated", "test"]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "name": "Patch File Frontmatter",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"frontmatter\": {\n        \"tags\": [\"new-tag\"]\n    }\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/files/{{path}}/frontmatter",
+              "host": ["{{base_url}}"],
+              "path": ["files", "{{path}}", "frontmatter"],
+              "variable": [
+                {
+                  "key": "path",
+                  "value": "path/to/file.md",
+                  "description": "Path to the markdown file"
+                }
+              ]
+            }
+          },
+          "response": [
+            {
+              "name": "Success",
+              "originalRequest": {
+                "method": "PATCH",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"frontmatter\": {\n        \"tags\": [\"new-tag\"]\n    }\n}"
+                },
+                "url": {
+                  "raw": "http://localhost:8000/files/Notes/test1.md/frontmatter",
+                  "protocol": "http",
+                  "host": ["localhost"],
+                  "port": "8000",
+                  "path": ["files", "Notes", "test1.md", "frontmatter"]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": {
+                "frontmatter": {
+                  "title": "Updated Title",
+                  "tags": ["new-tag"]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "name": "Get File Metadata",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/files/{{path}}/metadata",
+              "host": ["{{base_url}}"],
+              "path": ["files", "{{path}}", "metadata"],
+              "variable": [
+                {
+                  "key": "path",
+                  "value": "path/to/file.md",
+                  "description": "Path to the markdown file"
+                }
+              ]
+            }
+          },
+          "response": [
+            {
+              "name": "Success",
+              "originalRequest": {
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "http://localhost:8000/files/Notes/test1.md/metadata",
+                  "protocol": "http",
+                  "host": ["localhost"],
+                  "port": "8000",
+                  "path": ["files", "Notes", "test1.md", "metadata"]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": {
+                "type": "file",
+                "name": "test1.md",
+                "path": "Notes/test1.md",
+                "size": 12,
+                "created": "2024-03-20T10:00:00Z",
+                "modified": "2024-03-20T10:00:00Z"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Patch File Metadata",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"path\": \"Notes/moved.md\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/files/{{path}}/metadata",
+              "host": ["{{base_url}}"],
+              "path": ["files", "{{path}}", "metadata"],
+              "variable": [
+                {
+                  "key": "path",
+                  "value": "path/to/file.md",
+                  "description": "Path to the markdown file"
+                }
+              ]
+            }
+          },
+          "response": [
+            {
+              "name": "Success",
+              "originalRequest": {
+                "method": "PATCH",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"path\": \"Notes/moved.md\"\n}"
+                },
+                "url": {
+                  "raw": "http://localhost:8000/files/Notes/test1.md/metadata",
+                  "protocol": "http",
+                  "host": ["localhost"],
+                  "port": "8000",
+                  "path": ["files", "Notes", "test1.md", "metadata"]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": {
+                "type": "file",
+                "name": "moved.md",
+                "path": "Notes/moved.md",
+                "size": 12,
                 "created": "2024-03-20T10:00:00Z",
                 "modified": "2024-03-20T10:00:00Z"
               }
@@ -714,7 +838,7 @@
                   "type": "file",
                   "name": "test1.md",
                   "path": "Notes/test1.md",
-                  "content": "# Test File 1",
+                  "body": "# Test File 1",
                   "size": 12,
                   "created": "2024-03-20T10:00:00Z",
                   "modified": "2024-03-20T10:00:00Z"
@@ -775,7 +899,7 @@
           ]
         },
         {
-          "name": "Partial Update Folder",
+          "name": "Update Folder",
           "request": {
             "method": "PATCH",
             "header": [
@@ -786,7 +910,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"path\": \"new/path/to/folder\"\n}"
+              "raw": "{\n    \"path\": \"NewFolderName\"\n}"
             },
             "url": {
               "raw": "{{base_url}}/folders/{{path}}",
@@ -795,8 +919,8 @@
               "variable": [
                 {
                   "key": "path",
-                  "value": "current/path/to/folder",
-                  "description": "Current path of the folder"
+                  "value": "path/to/folder",
+                  "description": "Path to the folder"
                 }
               ]
             }
@@ -814,14 +938,14 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"path\": \"Projects_moved\"\n}"
+                  "raw": "{\n    \"path\": \"NewFolderName\"\n}"
                 },
                 "url": {
-                  "raw": "http://localhost:8000/folders/Projects",
+                  "raw": "http://localhost:8000/folders/NewFolder",
                   "protocol": "http",
                   "host": ["localhost"],
                   "port": "8000",
-                  "path": ["folders", "Projects"]
+                  "path": ["folders", "NewFolder"]
                 }
               },
               "status": "OK",
@@ -835,8 +959,8 @@
               ],
               "body": {
                 "type": "folder",
-                "name": "Projects_moved",
-                "path": "Projects_moved",
+                "name": "NewFolderName",
+                "path": "NewFolderName",
                 "created": "2024-03-20T10:00:00Z",
                 "modified": "2024-03-20T10:00:00Z"
               }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "fastapi>=0.115.12",
+    "python-frontmatter>=1.1.0",
     "uvicorn>=0.34.2",
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,10 @@ def test_vault():
             f.write("# Test File 2")
         with open(os.path.join(projects_dir, "test3.md"), "w") as f:
             f.write("# Test File 3")
+            
+        # Create test file with frontmatter
+        with open(os.path.join(notes_dir, "file_with_frontmatter.md"), "w") as f:
+            f.write("---\ntitle: New Note\ntags: [note, test]\n---\n# New File")
         
         yield tmp_dir
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -94,10 +94,11 @@ def test_auth_exceptions(client, monkeypatch, authScenario, route):
             "body": None,
             "expected_status": 200,
             "verify_response": lambda response: (
-                len(response.json()) == 3 and
+                len(response.json()) == 4 and
                 any(f["path"] == "Notes/test1.md" for f in response.json()) and
                 any(f["path"] == "Notes/test2.md" for f in response.json()) and
                 any(f["path"] == "Projects/test3.md" for f in response.json()) and
+                any(f["path"] == "Notes/file_with_frontmatter.md" for f in response.json()) and
                 all(f["type"] == "file" for f in response.json())
             )
         },{
@@ -120,7 +121,7 @@ def test_auth_exceptions(client, monkeypatch, authScenario, route):
                 response.json()["type"] == "file" and
                 response.json()["name"] == "test1.md" and
                 response.json()["path"] == "Notes/test1.md" and
-                response.json()["content"] == "# Test File 1" and
+                response.json()["body"] == "# Test File 1" and
                 response.json()["frontmatter"] is None and
                 response.json()["size"] == len("# Test File 1") and
                 is_iso_timestamp(response.json().get("created", "")) and
@@ -147,7 +148,7 @@ def test_auth_exceptions(client, monkeypatch, authScenario, route):
                 response.json()["type"] == "file" and
                 response.json()["name"] == "new_file.md" and
                 response.json()["path"] == "Notes/new_file.md" and
-                response.json()["content"] == "# New File" and
+                response.json()["body"] == "# New File" and
                 response.json()["frontmatter"] == {"title": "New Note", "tags": ["note", "test"]} and
                 response.json()["size"] == len("---\ntitle: New Note\ntags: [note, test]\n---\n# New File") and
                 is_iso_timestamp(response.json().get("created", "")) and
@@ -174,7 +175,7 @@ def test_auth_exceptions(client, monkeypatch, authScenario, route):
                 response.json()["type"] == "file" and
                 response.json()["name"] == "test1.md" and
                 response.json()["path"] == "Notes/test1.md" and
-                response.json()["content"] == "# Updated Content" and
+                response.json()["body"] == "# Updated Content" and
                 response.json()["frontmatter"] == {"title": "Updated Note", "tags": ["updated"]} and
                 response.json()["size"] == len("---\ntitle: Updated Note\ntags: [updated]\n---\n# Updated Content") and
                 is_iso_timestamp(response.json().get("created", "")) and
@@ -189,7 +190,7 @@ def test_auth_exceptions(client, monkeypatch, authScenario, route):
                 response.json()["type"] == "file" and
                 response.json()["name"] == "moved.md" and
                 response.json()["path"] == "Notes/moved.md" and
-                response.json()["content"] == "# Test File 1" and
+                response.json()["body"] == "# Test File 1" and
                 response.json()["size"] == len("# Test File 1") and
                 is_iso_timestamp(response.json().get("created", "")) and
                 is_iso_timestamp(response.json().get("modified", ""))
@@ -203,7 +204,7 @@ def test_auth_exceptions(client, monkeypatch, authScenario, route):
                 response.json()["type"] == "file" and
                 response.json()["name"] == "test1.md" and
                 response.json()["path"] == "Notes/test1.md" and
-                response.json()["content"] == "# Updated via PATCH" and
+                response.json()["body"] == "# Updated via PATCH" and
                 response.json()["frontmatter"] == {"title": "Patched Note", "tags": ["patched"]} and
                 response.json()["size"] == len("---\ntitle: Patched Note\ntags: [patched]\n---\n# Updated via PATCH") and
                 is_iso_timestamp(response.json().get("created", "")) and
@@ -218,7 +219,7 @@ def test_auth_exceptions(client, monkeypatch, authScenario, route):
                 response.json()["type"] == "file" and
                 response.json()["name"] == "moved.md" and
                 response.json()["path"] == "Notes/moved.md" and
-                response.json()["content"] == "# Updated content and path" and
+                response.json()["body"] == "# Updated content and path" and
                 response.json()["size"] == len("# Updated content and path") and
                 is_iso_timestamp(response.json().get("created", "")) and
                 is_iso_timestamp(response.json().get("modified", ""))
@@ -232,7 +233,7 @@ def test_auth_exceptions(client, monkeypatch, authScenario, route):
                 response.json()["type"] == "file" and
                 response.json()["name"] == "test1.md" and
                 response.json()["path"] == "Notes/test1.md" and
-                response.json()["content"] == "# Test File 1" and
+                response.json()["body"] == "# Test File 1" and
                 response.json()["size"] == len("# Test File 1") and
                 is_iso_timestamp(response.json().get("created", "")) and
                 is_iso_timestamp(response.json().get("modified", ""))
@@ -248,6 +249,99 @@ def test_auth_exceptions(client, monkeypatch, authScenario, route):
                 response.json()["path"] == "Projects_moved" and
                 is_iso_timestamp(response.json().get("created", "")) and
                 is_iso_timestamp(response.json().get("modified", ""))
+            )
+        },{
+            "method": "GET",
+            "route": "/files/Notes/test1.md/raw",
+            "body": None,
+            "expected_status": 200,
+            "verify_response": lambda response: (
+                response.text == "# Test File 1"
+            )
+        },{
+            "method": "GET",
+            "route": "/files/Notes/test1.md/metadata",
+            "body": None,
+            "expected_status": 200,
+            "verify_response": lambda response: (
+                response.json()["type"] == "file" and
+                response.json()["name"] == "test1.md" and
+                response.json()["path"] == "Notes/test1.md" and
+                "body" not in response.json() and
+                "frontmatter" not in response.json() and
+                response.json()["size"] == len("# Test File 1") and
+                is_iso_timestamp(response.json().get("created", "")) and
+                is_iso_timestamp(response.json().get("modified", ""))
+            )
+        },{
+            "method": "GET",
+            "route": "/files/Notes/test1.md/frontmatter",
+            "body": None,
+            "expected_status": 200,
+            "verify_response": lambda response: (
+                response.json()["frontmatter"] is None
+            )
+        },{
+            "method": "GET",
+            "route": "/files/Notes/test1.md/body",
+            "body": None,
+            "expected_status": 200,
+            "verify_response": lambda response: (
+                response.json()["body"] == "# Test File 1"
+            )
+        },{
+            "method": "GET",
+            "route": "/files/Notes/file_with_frontmatter.md",
+            "body": None,
+            "expected_status": 200,
+            "verify_response": lambda response: (
+                response.json()["type"] == "file" and
+                response.json()["name"] == "file_with_frontmatter.md" and
+                response.json()["path"] == "Notes/file_with_frontmatter.md" and
+                response.json()["body"] == "# New File" and
+                response.json()["frontmatter"] == {"title": "New Note", "tags": ["note", "test"]} and
+                response.json()["size"] == len("---\ntitle: New Note\ntags: [note, test]\n---\n# New File") and
+                is_iso_timestamp(response.json().get("created", "")) and
+                is_iso_timestamp(response.json().get("modified", ""))
+            )
+        },{
+            "method": "GET",
+            "route": "/files/Notes/file_with_frontmatter.md/raw",
+            "body": None,
+            "expected_status": 200,
+            "verify_response": lambda response: (
+                response.text == "---\ntitle: New Note\ntags: [note, test]\n---\n# New File"
+            )
+        },{
+            "method": "GET",
+            "route": "/files/Notes/file_with_frontmatter.md/metadata",
+            "body": None,
+            "expected_status": 200,
+            "verify_response": lambda response: (
+                response.json()["type"] == "file" and
+                response.json()["name"] == "file_with_frontmatter.md" and
+                response.json()["path"] == "Notes/file_with_frontmatter.md" and
+                "body" not in response.json() and
+                "frontmatter" not in response.json() and
+                response.json()["size"] == len("---\ntitle: New Note\ntags: [note, test]\n---\n# New File") and
+                is_iso_timestamp(response.json().get("created", "")) and
+                is_iso_timestamp(response.json().get("modified", ""))
+            )
+        },{
+            "method": "GET",
+            "route": "/files/Notes/file_with_frontmatter.md/frontmatter",
+            "body": None,
+            "expected_status": 200,
+            "verify_response": lambda response: (
+                response.json()["frontmatter"] == {"title": "New Note", "tags": ["note", "test"]}
+            )
+        },{
+            "method": "GET",
+            "route": "/files/Notes/file_with_frontmatter.md/body",
+            "body": None,
+            "expected_status": 200,
+            "verify_response": lambda response: (
+                response.json()["body"] == "# New File"
             )
         }
     ],
@@ -301,10 +395,11 @@ def test_hidden_directories(client):
     response = client.get("/files")
     assert response.status_code == 200
     files = response.json()
-    assert len(files) == 3
+    assert len(files) == 4
     assert any(f["path"] == "Notes/test1.md" for f in files)
     assert any(f["path"] == "Notes/test2.md" for f in files)
     assert any(f["path"] == "Projects/test3.md" for f in files)
+    assert any(f["path"] == "Notes/file_with_frontmatter.md" for f in files)
     assert not any(f["path"] == ".hidden/test.md" for f in files)
     
     response = client.get("/folders")
@@ -331,20 +426,18 @@ def test_hidden_directories(client):
 )
 def test_paths_with_spaces(client, path, encoded_path):
     # Test creating file with spaces
-    response = client.post(f"/files/{path}", json={"content": "# Test Content"})
+    response = client.post(f"/files/{encoded_path}", json={"content": "# Test Content"})
     assert response.status_code == 200
-    assert response.json()["path"] == path
-    assert response.json()["type"] == "file"
-    assert response.json()["content"] == "# Test Content"
+    assert response.json()["body"] == "# Test Content"
     
     # Test reading file with raw path
     response = client.get(f"/files/{path}")
     assert response.status_code == 200
-    assert response.json()["content"] == "# Test Content"
+    assert response.json()["body"] == "# Test Content"
     assert response.json()["type"] == "file"
     
     # Test reading file with URL-encoded path
     response = client.get(f"/files/{encoded_path}")
     assert response.status_code == 200
-    assert response.json()["content"] == "# Test Content"
+    assert response.json()["body"] == "# Test Content"
     assert response.json()["type"] == "file"

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -121,6 +121,7 @@ def test_auth_exceptions(client, monkeypatch, authScenario, route):
                 response.json()["name"] == "test1.md" and
                 response.json()["path"] == "Notes/test1.md" and
                 response.json()["content"] == "# Test File 1" and
+                response.json()["frontmatter"] is None and
                 response.json()["size"] == len("# Test File 1") and
                 is_iso_timestamp(response.json().get("created", "")) and
                 is_iso_timestamp(response.json().get("modified", ""))
@@ -140,14 +141,15 @@ def test_auth_exceptions(client, monkeypatch, authScenario, route):
         },{
             "method": "POST",
             "route": "/files/Notes/new_file.md",
-            "body": {"content": "# New File"},
+            "body": {"content": "---\ntitle: New Note\ntags: [note, test]\n---\n# New File"},
             "expected_status": 200,
             "verify_response": lambda response: (
                 response.json()["type"] == "file" and
                 response.json()["name"] == "new_file.md" and
                 response.json()["path"] == "Notes/new_file.md" and
                 response.json()["content"] == "# New File" and
-                response.json()["size"] == len("# New File") and
+                response.json()["frontmatter"] == {"title": "New Note", "tags": ["note", "test"]} and
+                response.json()["size"] == len("---\ntitle: New Note\ntags: [note, test]\n---\n# New File") and
                 is_iso_timestamp(response.json().get("created", "")) and
                 is_iso_timestamp(response.json().get("modified", ""))
             )
@@ -166,14 +168,15 @@ def test_auth_exceptions(client, monkeypatch, authScenario, route):
         },{
             "method": "PUT",
             "route": "/files/Notes/test1.md",
-            "body": {"content": "# Updated Content"},
+            "body": {"content": "---\ntitle: Updated Note\ntags: [updated]\n---\n# Updated Content"},
             "expected_status": 200,
             "verify_response": lambda response: (
                 response.json()["type"] == "file" and
                 response.json()["name"] == "test1.md" and
                 response.json()["path"] == "Notes/test1.md" and
                 response.json()["content"] == "# Updated Content" and
-                response.json()["size"] == len("# Updated Content") and
+                response.json()["frontmatter"] == {"title": "Updated Note", "tags": ["updated"]} and
+                response.json()["size"] == len("---\ntitle: Updated Note\ntags: [updated]\n---\n# Updated Content") and
                 is_iso_timestamp(response.json().get("created", "")) and
                 is_iso_timestamp(response.json().get("modified", ""))
             )
@@ -194,14 +197,15 @@ def test_auth_exceptions(client, monkeypatch, authScenario, route):
         },{
             "method": "PATCH",
             "route": "/files/Notes/test1.md",
-            "body": {"content": "# Updated via PATCH"},
+            "body": {"content": "---\ntitle: Patched Note\ntags: [patched]\n---\n# Updated via PATCH"},
             "expected_status": 200,
             "verify_response": lambda response: (
                 response.json()["type"] == "file" and
                 response.json()["name"] == "test1.md" and
                 response.json()["path"] == "Notes/test1.md" and
                 response.json()["content"] == "# Updated via PATCH" and
-                response.json()["size"] == len("# Updated via PATCH") and
+                response.json()["frontmatter"] == {"title": "Patched Note", "tags": ["patched"]} and
+                response.json()["size"] == len("---\ntitle: Patched Note\ntags: [patched]\n---\n# Updated via PATCH") and
                 is_iso_timestamp(response.json().get("created", "")) and
                 is_iso_timestamp(response.json().get("modified", ""))
             )

--- a/uv.lock
+++ b/uv.lock
@@ -129,6 +129,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi" },
+    { name = "python-frontmatter" },
     { name = "uvicorn" },
 ]
 
@@ -141,6 +142,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115.12" },
+    { name = "python-frontmatter", specifier = ">=1.1.0" },
     { name = "uvicorn", specifier = ">=0.34.2" },
 ]
 
@@ -224,6 +226,35 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634 },
+]
+
+[[package]]
+name = "python-frontmatter"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/de/910fa208120314a12f9a88ea63e03707261692af782c99283f1a2c8a5e6f/python-frontmatter-1.1.0.tar.gz", hash = "sha256:7118d2bd56af9149625745c58c9b51fb67e8d1294a0c76796dafdc72c36e5f6d", size = 16256 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/87/3c8da047b3ec5f99511d1b4d7a5bc72d4b98751c7e78492d14dc736319c5/python_frontmatter-1.1.0-py3-none-any.whl", hash = "sha256:335465556358d9d0e6c98bbeb69b1c969f2a4a21360587b9873bfc3b213407c1", size = 9834 },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/e3/3af305b830494fa85d95f6d95ef7fa73f2ee1cc8ef5b495c7c3269fb835f/PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba", size = 181309 },
+    { url = "https://files.pythonhosted.org/packages/45/9f/3b1c20a0b7a3200524eb0076cc027a970d320bd3a6592873c85c92a08731/PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1", size = 171679 },
+    { url = "https://files.pythonhosted.org/packages/7c/9a/337322f27005c33bcb656c655fa78325b730324c78620e8328ae28b64d0c/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133", size = 733428 },
+    { url = "https://files.pythonhosted.org/packages/a3/69/864fbe19e6c18ea3cc196cbe5d392175b4cf3d5d0ac1403ec3f2d237ebb5/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484", size = 763361 },
+    { url = "https://files.pythonhosted.org/packages/04/24/b7721e4845c2f162d26f50521b825fb061bc0a5afcf9a386840f23ea19fa/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5", size = 759523 },
+    { url = "https://files.pythonhosted.org/packages/2b/b2/e3234f59ba06559c6ff63c4e10baea10e5e7df868092bf9ab40e5b9c56b6/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc", size = 726660 },
+    { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597 },
+    { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527 },
+    { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446 },
 ]
 
 [[package]]


### PR DESCRIPTION
### Changes
- Added sub-resource routes for granular file operations:
  - `/files/{path}/raw` - Raw file content operations
  - `/files/{path}/metadata` - File metadata operations
  - `/files/{path}/frontmatter` - YAML frontmatter operations
  - `/files/{path}/body` - Markdown body operations
- Added frontmatter support using `python-frontmatter` library
- Restructured response schemas to separate metadata and content
- Updated tests to cover new endpoints and frontmatter functionality

### Technical Details
- Added `python-frontmatter>=1.1.0` dependency
- Improved error handling for file operations
- Enhanced test coverage for edge cases
- Updated API documentation with detailed endpoint descriptions

### Breaking Changes
- File response schema now separates metadata and content
- File creation/update endpoints now support structured content with frontmatter